### PR TITLE
Expose read-only BspNode accessors for external traversal

### DIFF
--- a/cpp_version/graph_drawing/bsp_node.h
+++ b/cpp_version/graph_drawing/bsp_node.h
@@ -32,6 +32,15 @@ class BspNode {
 		void removeEdge(Edge* edge);
 		void removeFace(Face* face);
 
+		// Read-only accessors for external traversal (collision-BSP construction).
+		// Added so consumers outside pmugg can walk the tree without taking a
+		// copy of the underlying graph drawing.
+		int getParentId() const { return parentId; }
+		int getAboveId()  const { return aboveId; }
+		int getBelowId()  const { return belowId; }
+		const Plane* getPlanePtr() const { return plane; }
+		const vector<int>& getFaceIds() const { return faceIds; }
+
 	private:
 		Model* model;
 		Plane* plane;

--- a/cpp_version/graph_drawing/bsp_node.h
+++ b/cpp_version/graph_drawing/bsp_node.h
@@ -32,9 +32,6 @@ class BspNode {
 		void removeEdge(Edge* edge);
 		void removeFace(Face* face);
 
-		// Read-only accessors for external traversal (collision-BSP construction).
-		// Added so consumers outside pmugg can walk the tree without taking a
-		// copy of the underlying graph drawing.
 		int getParentId() const { return parentId; }
 		int getAboveId()  const { return aboveId; }
 		int getBelowId()  const { return belowId; }


### PR DESCRIPTION
## Context

I'm using pmugg as a procedural geometry layer inside a larger application
(a small FPS map exporter) that needs to build its own collision BSP from
the same partition pmugg already computes. Today there's no way to walk
the resulting `BspNode` tree from outside the class — every field is
private and the only public read accessor is `getId()` — so consumers
either have to duplicate the partition work or maintain a fork.

This PR adds a small set of read-only accessors so external code can walk
the tree without breaking encapsulation.

## What this PR does

Adds five `const` inline accessors to `BspNode`:

| Accessor | Returns | Use |
| --- | --- | --- |
| `getParentId()` | `int` | Walk up to the root |
| `getAboveId()` | `int` | Descend into the above half-space |
| `getBelowId()` | `int` | Descend into the below half-space |
| `getPlanePtr()` | `const Plane*` | Classify external geometry vs. this node |
| `getFaceIds()` | `const vector<int>&` | Enumerate faces that landed in this node |

Header-only change. No new dependencies. No behavior change for existing
callers — all private members and methods remain private.

## Why this design

- **Inline + `const`**: zero-cost accessors. No vtable, no extra symbols.
- **`getPlanePtr()` (not `getPlane()`)**: avoids colliding with the
  existing private `Plane* getPlane()`. Public version is `const`-qualified
  and returns `const Plane*` to make it explicit that consumers can't
  mutate the partition.
- **`getFaceIds()` returns `const vector<int>&`**: cheap; lets callers
  iterate without copying.
- **No `getEdgeIds()` for now**: I haven't needed it externally yet.
  Easy to add later if anyone does.

## Verification

- Built `cpp_version/pmugg.sln` (Release|x64, MSBuild via VS 2022 Build
  Tools) on Windows 11 — pmugg.exe and pmugg dll.dll both rebuild clean.
- Sample traversal (in my application):
  ```cpp
  void walk(const Model& model, int nodeId, int depth) {
      const BspNode& n = model.getBspNode(nodeId);
      printf(\"%*sBSP %d (parent %d)\n\", depth*2, \"\", nodeId, n.getParentId());
      for (int faceId : n.getFaceIds()) { /* ... */ }
      if (n.getAboveId() >= 0) walk(model, n.getAboveId(), depth+1);
      if (n.getBelowId() >= 0) walk(model, n.getBelowId(), depth+1);
  }
  ```
- No perf change expected (header-only accessor additions). I'm authoring
  a benchmark harness for upcoming PRs in this series; once it's ready I
  can drop a no-regression table in this PR if you want.

## Notes for the maintainer

This is the first of a small series of PRs I'd like to upstream from a
local fork. The others (parallelization, edge-placement caching, FFD
bending replacement, etc.) build on each other — happy to send each as a
separate PR for independent review. Opening this one as draft in case
you want to discuss the API surface (naming, what to expose) before I
land it.