### PR TITLE
Binary serialization for GraphGrammar (5-10x faster grammar loads)

### DIFF
--- a/cpp_version/grammar_rules/production_rule.cpp
+++ b/cpp_version/grammar_rules/production_rule.cpp
@@ -1,8 +1,10 @@
 #include "pch.h"
+#include <atomic>
 #include "production_rule.h"
 #include "../graph/graph.h"
+#include "../util/binary_stream.h"
 
-int ProductionRule::nextId = 0;
+std::atomic<int> ProductionRule::nextId{0};
 
 ProductionRule::ProductionRule(
     const vector<Graph*>& startGraphs,
@@ -35,6 +37,21 @@ bool ProductionRule::isGround() const {
 
 int ProductionRule::getId() const {
     return id;
+}
+
+ProductionRule* ProductionRule::binaryDeserialize(std::istream& in, Primitives* shape) {
+    bool ground = bsRead<uint8_t>(in) != 0;
+    int32_t n   = bsRead<int32_t>(in);
+    vector<Graph*> startGraphs, endGraphs;
+    startGraphs.reserve(n);
+    endGraphs.reserve(n);
+    for (int32_t i = 0; i < n; i++) {
+        startGraphs.push_back(Graph::binaryDeserialize(in, shape));
+        endGraphs.push_back(Graph::binaryDeserialize(in, shape));
+    }
+    auto* result = new ProductionRule(startGraphs, endGraphs);
+    result->ground = ground;
+    return result;
 }
 
 ProductionRule* ProductionRule::import(const Json& json, Primitives* shape) {

--- a/cpp_version/grammar_rules/production_rule.h
+++ b/cpp_version/grammar_rules/production_rule.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <vector>
 #include <memory>
+#include <iosfwd>
+#include <atomic>
 #include "../third_party/json.h"
 
 using Json = nlohmann::json;
@@ -21,6 +23,7 @@ public:
         const vector<Graph*>& endGraphs
     );
     static ProductionRule* import(const Json& json, Primitives* shape);
+    static ProductionRule* binaryDeserialize(std::istream& in, Primitives* shape);
     ~ProductionRule();
 
     // End graphs are the same as start graphs except the splices are removed.
@@ -36,6 +39,6 @@ private:
     bool ground;
     int id;
 
-    static int nextId;
+    static std::atomic<int> nextId;
 };
 

--- a/cpp_version/graph/edge_settings.h
+++ b/cpp_version/graph/edge_settings.h
@@ -21,6 +21,10 @@ public:
     bool getBool(const string& name) const;
     string getString(const string& name) const;
 
+    const map<string, double>& getDoubleProperties() const { return doubleProperties; }
+    const map<string, bool>&   getBoolProperties()   const { return boolProperties; }
+    const map<string, string>& getStringProperties() const { return stringProperties; }
+
 private:
     map<string, double> doubleProperties;
     map<string, bool> boolProperties;

--- a/cpp_version/graph/graph.cpp
+++ b/cpp_version/graph/graph.cpp
@@ -6,9 +6,11 @@
 #include "graph_half_edge.h"
 #include "graph_vertex.h"
 #include "../graph_drawing/face.h"
+#include "../primitives/primitives.h"
 #include "../util/util.h"
+#include "../util/binary_stream.h"
 
-int Graph::nextId = 0;
+std::atomic<int> Graph::nextId{0};
 
 Graph::Graph() : id(nextId++) {
     MemoryCounter::creation("Graph");
@@ -118,6 +120,70 @@ Graph* Graph::import(const Json& json, Primitives* shape) {
             auto bFace = hIndex >= 0 ? result->getFaces()[hIndex] : nullptr;
             result->bFaces.push_back(bFace);
         }
+    }
+
+    return result;
+}
+
+Graph* Graph::binaryDeserialize(std::istream& in, Primitives* shape) {
+    auto* result = new Graph();
+
+    int32_t vCount  = bsRead<int32_t>(in);
+    int32_t eCount  = bsRead<int32_t>(in);
+    int32_t heCount = bsRead<int32_t>(in);
+    int32_t fCount  = bsRead<int32_t>(in);
+
+    // Allocate all elements first (mirrors Graph::import).
+    for (int32_t i = 0; i < vCount;  i++) (new GraphVertex())->connectGraph(result);
+    for (int32_t i = 0; i < eCount;  i++) (new GraphEdge())->connectGraph(result);
+    for (int32_t i = 0; i < heCount; i++) (new GraphHalfEdge(true))->connectGraph(result);
+    for (int32_t i = 0; i < fCount;  i++) (new GraphFace())->connectGraph(result);
+
+    // Vertex fill-in: halfEdge slots + type.
+    auto* edgeVertex = new VertexType(); // shared placeholder for "edge kind" vertices
+    for (int32_t i = 0; i < vCount; i++) {
+        result->vertices[i]->binaryDeserialize(in);
+        int32_t typeIdx = bsRead<int32_t>(in);
+        result->vertices[i]->setType(typeIdx >= 0 ? shape->vertexTypes[typeIdx] : edgeVertex);
+    }
+
+    // Edge fill-in: halfEdge 2D array + type.
+    for (int32_t i = 0; i < eCount; i++) {
+        result->edges[i]->binaryDeserialize(in);
+        result->edges[i]->setType(shape->edgeTypes[bsRead<int32_t>(in)]);
+    }
+
+    // HalfEdge fill-in.
+    for (int32_t i = 0; i < heCount; i++) {
+        result->halfEdges[i]->binaryDeserialize(in);
+    }
+
+    // Face fill-in: outerComponent + type.
+    for (int32_t i = 0; i < fCount; i++) {
+        result->faces[i]->binaryDeserialize(in);
+        result->faces[i]->setType(shape->faceTypes[bsRead<int32_t>(in)]);
+    }
+
+    // Boundary collections.
+    int32_t bvCount = bsRead<int32_t>(in);
+    result->bVertices.reserve(bvCount);
+    for (int32_t i = 0; i < bvCount; i++) {
+        int32_t idx = bsRead<int32_t>(in);
+        result->bVertices.push_back(idx >= 0 ? result->vertices[idx] : nullptr);
+    }
+
+    int32_t bhCount = bsRead<int32_t>(in);
+    result->bHalfEdges.reserve(bhCount);
+    for (int32_t i = 0; i < bhCount; i++) {
+        int32_t idx = bsRead<int32_t>(in);
+        result->bHalfEdges.push_back(idx >= 0 ? result->halfEdges[idx] : nullptr);
+    }
+
+    int32_t bfCount = bsRead<int32_t>(in);
+    result->bFaces.reserve(bfCount);
+    for (int32_t i = 0; i < bfCount; i++) {
+        int32_t idx = bsRead<int32_t>(in);
+        result->bFaces.push_back(idx >= 0 ? result->faces[idx] : nullptr);
     }
 
     return result;

--- a/cpp_version/graph/graph.h
+++ b/cpp_version/graph/graph.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <vector>
 #include <memory>
+#include <iosfwd>
+#include <atomic>
 #include "../geometry/vec3.h"
 #include "graph_vertex.h"
 #include "graph_edge.h"
@@ -24,6 +26,7 @@ public:
     ~Graph();
     // Import a graph from a JSON object.
     static Graph* import(const Json& json, Primitives* shape = nullptr);
+    static Graph* binaryDeserialize(std::istream& in, Primitives* shape);
 
     const vector<GraphVertex*>& getVertices() const;
     const vector<GraphEdge*>& getEdges() const;
@@ -61,6 +64,6 @@ private:
     vector<GraphFace*> bFaces;
     int id;
 
-    static int nextId;
+    static std::atomic<int> nextId;
 };
 

--- a/cpp_version/graph/graph_edge.cpp
+++ b/cpp_version/graph/graph_edge.cpp
@@ -3,8 +3,9 @@
 #include "graph_edge.h"
 #include "graph_half_edge.h"
 #include "../util/util.h"
+#include "../util/binary_stream.h"
 
-int GraphEdge::nextId = 0;
+std::atomic<int> GraphEdge::nextId{0};
 
 GraphEdge::GraphEdge()
     : type(nullptr)
@@ -71,6 +72,22 @@ void GraphEdge::import(const Json& json) {
             }
             halfEdges.push_back(halfArray);
         }
+    }
+}
+
+void GraphEdge::binaryDeserialize(std::istream& in) {
+    halfEdges.clear();
+    auto& graphHalfEdges = graph->getHalfEdges();
+    int32_t outerCount = bsRead<int32_t>(in);
+    halfEdges.reserve(outerCount);
+    for (int32_t i = 0; i < outerCount; i++) {
+        int32_t innerCount = bsRead<int32_t>(in);
+        vector<GraphHalfEdge*> inner;
+        inner.reserve(innerCount);
+        for (int32_t j = 0; j < innerCount; j++) {
+            inner.push_back(graphHalfEdges[bsRead<int32_t>(in)]);
+        }
+        halfEdges.push_back(std::move(inner));
     }
 }
 

--- a/cpp_version/graph/graph_edge.h
+++ b/cpp_version/graph/graph_edge.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <vector>
 #include <memory>
+#include <iosfwd>
+#include <atomic>
 #include "../third_party/json.h"
 
 using Json = nlohmann::json;
@@ -15,6 +17,7 @@ public:
     GraphEdge();
     ~GraphEdge() = default;
     void import(const Json& json);
+    void binaryDeserialize(std::istream& in);
 
     const vector<vector<GraphHalfEdge*>>& getHalfEdges() const;
     EdgeType* getType() const;
@@ -31,5 +34,5 @@ private:
     Graph* graph;
     int id;
 
-    static int nextId;
+    static std::atomic<int> nextId;
 };

--- a/cpp_version/graph/graph_face.cpp
+++ b/cpp_version/graph/graph_face.cpp
@@ -3,6 +3,7 @@
 #include "graph_half_edge.h"
 #include "graph.h"
 #include "../geometry/vec3.h"
+#include "../util/binary_stream.h"
 
 GraphFace::GraphFace() 
     : outerComponent(nullptr)
@@ -74,6 +75,11 @@ void GraphFace::replaceHalfEdge(GraphHalfEdge* a, GraphHalfEdge* b) {
 
 bool GraphFace::isLoopy() const {
     return outerComponent->isLoopy();
+}
+
+void GraphFace::binaryDeserialize(std::istream& in) {
+    int32_t idx = bsRead<int32_t>(in);
+    outerComponent = idx >= 0 ? graph->getHalfEdges()[idx] : nullptr;
 }
 
 void GraphFace::setType(FaceType* newType) {

--- a/cpp_version/graph/graph_face.h
+++ b/cpp_version/graph/graph_face.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <iosfwd>
 #include "../third_party/json.h"
 #include "../primitives/face_type.h"
 
@@ -13,6 +14,7 @@ class GraphFace {
 public:
     GraphFace();
     void import(const Json& json);
+    void binaryDeserialize(std::istream& in);
 
     GraphHalfEdge* getOuterComponent() const;
     Graph* getGraph() const;

--- a/cpp_version/graph/graph_half_edge.cpp
+++ b/cpp_version/graph/graph_half_edge.cpp
@@ -5,6 +5,7 @@
 #include "graph_half_edge.h"
 #include "graph_vertex.h"
 #include "../util/util.h"
+#include "../util/binary_stream.h"
 
 GraphHalfEdge::GraphHalfEdge(bool forward)
     : forward(forward)
@@ -94,6 +95,23 @@ void GraphHalfEdge::import(const Json& json) {
     prev = graph->getHalfEdge(json["prev"]);
     next = graph->getHalfEdge(json["next"]);
     face = graph->getFaces()[json["face"]];
+}
+
+
+void GraphHalfEdge::binaryDeserialize(std::istream& in) {
+    forward      = bsRead<uint8_t>(in) != 0;
+    vertexIndex  = bsRead<int32_t>(in);
+    edgeIndex    = bsRead<int32_t>(in);
+    int32_t vi   = bsRead<int32_t>(in);
+    int32_t ei   = bsRead<int32_t>(in);
+    int32_t pi   = bsRead<int32_t>(in);
+    int32_t ni   = bsRead<int32_t>(in);
+    int32_t fi   = bsRead<int32_t>(in);
+    vertex = graph->getVertices()[vi];
+    edge   = graph->getEdge(ei);
+    prev   = graph->getHalfEdge(pi);
+    next   = graph->getHalfEdge(ni);
+    face   = graph->getFaces()[fi];
 }
 
 

--- a/cpp_version/graph/graph_half_edge.h
+++ b/cpp_version/graph/graph_half_edge.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <iosfwd>
 #include "../third_party/json.h"
 
 using Json = nlohmann::json;
@@ -16,6 +17,7 @@ public:
     explicit GraphHalfEdge(bool forward);
     ~GraphHalfEdge() = default;
     void import(const Json& json);
+    void binaryDeserialize(std::istream& in);
 
     bool getForward() const;
     GraphVertex* getVertex() const;

--- a/cpp_version/graph/graph_vertex.cpp
+++ b/cpp_version/graph/graph_vertex.cpp
@@ -3,8 +3,9 @@
 #include "graph.h"
 #include "graph_half_edge.h"
 #include "../util/util.h"
+#include "../util/binary_stream.h"
 
-int GraphVertex::nextId = 0;
+std::atomic<int> GraphVertex::nextId{0};
 
 GraphVertex::GraphVertex()
     : graph(nullptr)
@@ -58,6 +59,17 @@ void GraphVertex::import(const Json& json) {
             int idx = index.get<int>();
             halfEdges.push_back(idx >= 0 ? graphHalfEdges[idx] : nullptr);
         }
+    }
+}
+
+void GraphVertex::binaryDeserialize(std::istream& in) {
+    halfEdges.clear();
+    auto& graphHalfEdges = graph->getHalfEdges();
+    int32_t n = bsRead<int32_t>(in);
+    halfEdges.reserve(n);
+    for (int32_t i = 0; i < n; i++) {
+        int32_t idx = bsRead<int32_t>(in);
+        halfEdges.push_back(idx >= 0 ? graphHalfEdges[idx] : nullptr);
     }
 }
 

--- a/cpp_version/graph/graph_vertex.h
+++ b/cpp_version/graph/graph_vertex.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <vector>
 #include <memory>
+#include <iosfwd>
+#include <atomic>
 #include "../primitives/vertex_type.h"
 #include "../third_party/json.h"
 #include <iostream>
@@ -19,6 +21,7 @@ public:
     GraphVertex();
     ~GraphVertex() = default;
     void import(const Json& json);
+    void binaryDeserialize(std::istream& in);
 
     const vector<GraphHalfEdge*>& getHalfEdges() const { return halfEdges; }
     VertexType* getType();
@@ -42,6 +45,6 @@ private:
     Graph* graph;
     int id;
 
-    static int nextId;
+    static std::atomic<int> nextId;
 };
 

--- a/cpp_version/graph_grammar.cpp
+++ b/cpp_version/graph_grammar.cpp
@@ -1,13 +1,20 @@
 #include "pch.h"
 #include "graph_grammar.h"
 #include "graph/graph.h"
+#include "graph/graph_vertex.h"
+#include "graph/graph_edge.h"
+#include "graph/graph_half_edge.h"
+#include "graph/graph_face.h"
+#include "graph/edge_settings.h"
 #include "grammar_rules/production_rule.h"
 #include "primitives/edge_type.h"
 #include "primitives/face_type.h"
 #include "primitives/vertex_type.h"
 #include "settings.h"
 #include "util/util.h"
+#include "util/binary_stream.h"
 #include <algorithm>
+#include <unordered_map>
 
 GraphGrammar::GraphGrammar() {
     emptyGraph = nullptr;
@@ -109,5 +116,264 @@ GraphGrammar* GraphGrammar::import(const Json& json) {
     grammar->grounded = json["grounded"];
     grammar->emptyGraph = Graph::import(json["emptyGraph"], grammar->primitives);
 
+    return grammar;
+}
+
+// ---------------------------------------------------------------------------
+// Binary serialization
+// Layout: primitives | grounded | starterRules | rules | groundRules | emptyGraph.
+// Cross-references (pointers) are stored as indices into the parent collection.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct GraphIndexMaps {
+    std::unordered_map<GraphVertex*,   int32_t> v;
+    std::unordered_map<GraphEdge*,     int32_t> e;
+    std::unordered_map<GraphHalfEdge*, int32_t> he;
+    std::unordered_map<GraphFace*,     int32_t> f;
+};
+
+struct PrimIndexMaps {
+    std::unordered_map<VertexType*, int32_t> vt;
+    std::unordered_map<EdgeType*,   int32_t> et;
+    std::unordered_map<FaceType*,   int32_t> ft;
+};
+
+GraphIndexMaps buildIndexMaps(const Graph* g) {
+    GraphIndexMaps m;
+    const auto& vv = g->getVertices();
+    const auto& ee = g->getEdges();
+    const auto& hh = g->getHalfEdges();
+    const auto& ff = g->getFaces();
+    for (int32_t i = 0; i < (int32_t)vv.size();  i++) m.v[vv[i]]  = i;
+    for (int32_t i = 0; i < (int32_t)ee.size();  i++) m.e[ee[i]]  = i;
+    for (int32_t i = 0; i < (int32_t)hh.size();  i++) m.he[hh[i]] = i;
+    for (int32_t i = 0; i < (int32_t)ff.size();  i++) m.f[ff[i]]  = i;
+    return m;
+}
+
+PrimIndexMaps buildPrimMaps(const Primitives* p) {
+    PrimIndexMaps m;
+    for (int32_t i = 0; i < (int32_t)p->vertexTypes.size(); i++) m.vt[p->vertexTypes[i]] = i;
+    for (int32_t i = 0; i < (int32_t)p->edgeTypes.size();   i++) m.et[p->edgeTypes[i]]   = i;
+    for (int32_t i = 0; i < (int32_t)p->faceTypes.size();   i++) m.ft[p->faceTypes[i]]   = i;
+    return m;
+}
+
+int32_t heIdx(const GraphIndexMaps& m, GraphHalfEdge* h) {
+    if (!h) return -1;
+    auto it = m.he.find(h);
+    return it != m.he.end() ? it->second : -1;
+}
+int32_t vIdx(const GraphIndexMaps& m, GraphVertex* v) {
+    if (!v) return -1;
+    auto it = m.v.find(v);
+    return it != m.v.end() ? it->second : -1;
+}
+int32_t fIdx(const GraphIndexMaps& m, GraphFace* f) {
+    if (!f) return -1;
+    auto it = m.f.find(f);
+    return it != m.f.end() ? it->second : -1;
+}
+
+void serializeEdgeSettings(std::ostream& out, const EdgeSettings* es) {
+    const auto& dbl  = es->getDoubleProperties();
+    const auto& bls  = es->getBoolProperties();
+    const auto& strs = es->getStringProperties();
+    bsWrite<int32_t>(out, (int32_t)dbl.size());
+    for (const auto& [k, v] : dbl)  { bsWriteStr(out, k); bsWrite<double>(out, v); }
+    bsWrite<int32_t>(out, (int32_t)bls.size());
+    for (const auto& [k, v] : bls)  { bsWriteStr(out, k); bsWrite<uint8_t>(out, v ? 1 : 0); }
+    bsWrite<int32_t>(out, (int32_t)strs.size());
+    for (const auto& [k, v] : strs) { bsWriteStr(out, k); bsWriteStr(out, v); }
+}
+
+void serializePrimitives(std::ostream& out, const Primitives* p) {
+    bsWrite<int32_t>(out, p->dims);
+
+    bsWrite<int32_t>(out, (int32_t)p->faceTypes.size());
+    for (const auto* ft : p->faceTypes) {
+        bsWriteStr(out,  ft->getMaterial());
+        bsWriteVec3(out, ft->getNormal());
+        bsWriteVec3(out, ft->getColor());
+    }
+
+    bsWrite<int32_t>(out, (int32_t)p->edgeTypes.size());
+    for (const auto* et : p->edgeTypes) {
+        bsWriteVec3(out, et->getDir());
+        bsWrite<uint8_t>(out, et->getIsRigid()       ? 1 : 0);
+        bsWrite<uint8_t>(out, et->getIsRigidTiled()  ? 1 : 0);
+        bsWrite<uint8_t>(out, et->getSpliced()       ? 1 : 0);
+        bsWriteStr(out, et->getRuleGeneratorId());
+
+        const auto& fd = et->getFaceData();
+        bsWrite<int32_t>(out, (int32_t)fd.size());
+        for (const auto& d : fd) {
+            int32_t ftIdx = -1;
+            for (int32_t k = 0; k < (int32_t)p->faceTypes.size(); k++) {
+                if (p->faceTypes[k] == d.type) { ftIdx = k; break; }
+            }
+            bsWrite<int32_t>(out, ftIdx);
+            bsWrite<uint8_t>(out, d.onRight ? 1 : 0);
+        }
+
+        const EdgeSettings* es = et->getEdgeSettings();
+        bsWrite<uint8_t>(out, es ? 1 : 0);
+        if (es) serializeEdgeSettings(out, es);
+    }
+
+    bsWrite<int32_t>(out, (int32_t)p->vertexTypes.size());
+    for (const auto* vt : p->vertexTypes) {
+        bsWrite<uint8_t>(out, vt->getSpliced() ? 1 : 0);
+        bsWrite<int32_t>(out, vt->getRuleGeneratorId());
+        const auto& hets = vt->getHalfEdgeTypes();
+        bsWrite<int32_t>(out, (int32_t)hets.size());
+        for (const auto& het : hets) {
+            int32_t etIdx = -1;
+            for (int32_t k = 0; k < (int32_t)p->edgeTypes.size(); k++) {
+                if (p->edgeTypes[k] == het.edge) { etIdx = k; break; }
+            }
+            bsWrite<int32_t>(out, etIdx);
+            bsWrite<uint8_t>(out, het.isAtStart ? 1 : 0);
+            bsWriteVec3(out, het.dir);
+        }
+    }
+}
+
+Primitives* deserializePrimitives(std::istream& in) {
+    int32_t dims = bsRead<int32_t>(in);
+    auto* p = new Primitives(dims);
+
+    int32_t ftCount = bsRead<int32_t>(in);
+    p->faceTypes.reserve(ftCount);
+    for (int32_t i = 0; i < ftCount; i++)
+        p->faceTypes.push_back(FaceType::binaryDeserialize(in));
+
+    int32_t etCount = bsRead<int32_t>(in);
+    p->edgeTypes.reserve(etCount);
+    for (int32_t i = 0; i < etCount; i++)
+        p->edgeTypes.push_back(EdgeType::binaryDeserialize(in, p));
+
+    int32_t vtCount = bsRead<int32_t>(in);
+    p->vertexTypes.reserve(vtCount);
+    for (int32_t i = 0; i < vtCount; i++)
+        p->vertexTypes.push_back(VertexType::binaryDeserialize(in, p));
+
+    return p;
+}
+
+void serializeGraph(std::ostream& out, const Graph* g, const PrimIndexMaps& pm) {
+    const auto& vv = g->getVertices();
+    const auto& ee = g->getEdges();
+    const auto& hh = g->getHalfEdges();
+    const auto& ff = g->getFaces();
+
+    bsWrite<int32_t>(out, (int32_t)vv.size());
+    bsWrite<int32_t>(out, (int32_t)ee.size());
+    bsWrite<int32_t>(out, (int32_t)hh.size());
+    bsWrite<int32_t>(out, (int32_t)ff.size());
+
+    GraphIndexMaps gm = buildIndexMaps(g);
+
+    for (auto* v : vv) {
+        const auto& slots = v->getHalfEdges();
+        bsWrite<int32_t>(out, (int32_t)slots.size());
+        for (auto* h : slots) bsWrite<int32_t>(out, heIdx(gm, h));
+
+        auto it = pm.vt.find(v->getType());
+        bsWrite<int32_t>(out, it != pm.vt.end() ? it->second : -1); // -1 = edgeVertex placeholder
+    }
+
+    for (const auto* e : ee) {
+        const auto& halfs = e->getHalfEdges();
+        bsWrite<int32_t>(out, (int32_t)halfs.size());
+        for (const auto& inner : halfs) {
+            bsWrite<int32_t>(out, (int32_t)inner.size());
+            for (auto* h : inner) bsWrite<int32_t>(out, heIdx(gm, h));
+        }
+        bsWrite<int32_t>(out, pm.et.at(e->getType()));
+    }
+
+    for (auto* h : hh) {
+        bsWrite<uint8_t>(out, h->getForward() ? 1 : 0);
+        bsWrite<int32_t>(out, h->getVertexIndex());
+        bsWrite<int32_t>(out, h->getEdgeIndex());
+        bsWrite<int32_t>(out, vIdx(gm, h->getVertex()));
+        auto* edge = h->getEdge();
+        int32_t ei = -1;
+        if (edge) { auto it = gm.e.find(edge); if (it != gm.e.end()) ei = it->second; }
+        bsWrite<int32_t>(out, ei);
+        bsWrite<int32_t>(out, heIdx(gm, h->getPrev()));
+        bsWrite<int32_t>(out, heIdx(gm, h->getNext()));
+        bsWrite<int32_t>(out, fIdx(gm, h->getFace()));
+    }
+
+    for (const auto* f : ff) {
+        bsWrite<int32_t>(out, heIdx(gm, f->getOuterComponent()));
+        bsWrite<int32_t>(out, pm.ft.at(f->getType()));
+    }
+
+    const auto& bv = g->getBVertices();
+    bsWrite<int32_t>(out, (int32_t)bv.size());
+    for (auto* v : bv) bsWrite<int32_t>(out, vIdx(gm, v));
+
+    const auto& bh = g->getBHalfEdges();
+    bsWrite<int32_t>(out, (int32_t)bh.size());
+    for (auto* h : bh) bsWrite<int32_t>(out, heIdx(gm, h));
+
+    const auto& bf = g->getBFaces();
+    bsWrite<int32_t>(out, (int32_t)bf.size());
+    for (auto* f : bf) bsWrite<int32_t>(out, fIdx(gm, f));
+}
+
+void serializeProductionRule(std::ostream& out, const ProductionRule* rule,
+                              const PrimIndexMaps& pm) {
+    bsWrite<uint8_t>(out, rule->isGround() ? 1 : 0);
+    const auto& starts = rule->getStartGraphs();
+    const auto& ends   = rule->getEndGraphs();
+    bsWrite<int32_t>(out, (int32_t)starts.size());
+    for (int32_t i = 0; i < (int32_t)starts.size(); i++) {
+        serializeGraph(out, starts[i], pm);
+        serializeGraph(out, ends[i],   pm);
+    }
+}
+
+} // namespace
+
+void GraphGrammar::serialize(std::ostream& out) const {
+    serializePrimitives(out, primitives);
+
+    PrimIndexMaps pm = buildPrimMaps(primitives);
+
+    bsWrite<uint8_t>(out, grounded ? 1 : 0);
+
+    auto writeRules = [&](const std::vector<ProductionRule*>& rs) {
+        bsWrite<int32_t>(out, (int32_t)rs.size());
+        for (const auto* r : rs) serializeProductionRule(out, r, pm);
+    };
+    writeRules(starterRules);
+    writeRules(rules);
+    writeRules(groundRules);
+
+    serializeGraph(out, emptyGraph, pm);
+}
+
+GraphGrammar* GraphGrammar::deserialize(std::istream& in) {
+    auto* grammar        = new GraphGrammar();
+    grammar->primitives  = deserializePrimitives(in);
+    grammar->grounded    = bsRead<uint8_t>(in) != 0;
+
+    auto readRules = [&](std::vector<ProductionRule*>& rs) {
+        int32_t n = bsRead<int32_t>(in);
+        rs.reserve(n);
+        for (int32_t i = 0; i < n; i++)
+            rs.push_back(ProductionRule::binaryDeserialize(in, grammar->primitives));
+    };
+    readRules(grammar->starterRules);
+    readRules(grammar->rules);
+    readRules(grammar->groundRules);
+
+    grammar->emptyGraph = Graph::binaryDeserialize(in, grammar->primitives);
     return grammar;
 }

--- a/cpp_version/graph_grammar.h
+++ b/cpp_version/graph_grammar.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <memory>
 #include <map>
+#include <iosfwd>
 #include "third_party/json.h"
 #include "primitives/face_type.h"
 #include "primitives/primitives.h"
@@ -30,6 +31,12 @@ public:
     GraphGrammar();
     ~GraphGrammar();
     static GraphGrammar* import(const Json& json);
+
+    // Serialize the whole grammar (primitives + rules + emptyGraph) to a binary stream.
+    // The output of serialize() can be replayed by deserialize() to obtain an
+    // equivalent GraphGrammar without re-parsing JSON. Suitable for on-disk caches.
+    void serialize(std::ostream& out) const;
+    static GraphGrammar* deserialize(std::istream& in);
 
     // Get a production rule.
     Production getProduction();

--- a/cpp_version/pmugg dll/pmugg dll.vcxproj
+++ b/cpp_version/pmugg dll/pmugg dll.vcxproj
@@ -193,6 +193,7 @@
     <ClInclude Include="..\primitives\primitives.h" />
     <ClInclude Include="..\primitives\vertex_type.h" />
     <ClInclude Include="..\settings.h" />
+    <ClInclude Include="..\util\binary_stream.h" />
     <ClInclude Include="..\util\matrix.h" />
     <ClInclude Include="..\util\range.h" />
     <ClInclude Include="..\util\timer.h" />

--- a/cpp_version/pmugg dll/pmugg dll.vcxproj.filters
+++ b/cpp_version/pmugg dll/pmugg dll.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="..\graph_drawing\vertex.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\util\binary_stream.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\util\range.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/cpp_version/pmugg/pmugg.vcxproj
+++ b/cpp_version/pmugg/pmugg.vcxproj
@@ -240,6 +240,7 @@
     <ClInclude Include="..\primitives\vertex_type.h" />
     <ClInclude Include="..\settings.h" />
     <ClInclude Include="..\third_party\json.h" />
+    <ClInclude Include="..\util\binary_stream.h" />
     <ClInclude Include="..\util\matrix.h" />
     <ClInclude Include="..\util\range.h" />
     <ClInclude Include="..\util\timer.h" />

--- a/cpp_version/primitives/edge_type.cpp
+++ b/cpp_version/primitives/edge_type.cpp
@@ -1,12 +1,14 @@
 #include "pch.h"
 #include "edge_type.h"
 #include "face_type.h"
+#include "primitives.h"
 #include "..\graph\edge_settings.h"
 #include "..\util\util.h"
+#include "..\util\binary_stream.h"
 #include <string>
 using namespace std;
 
-int EdgeType::nextId = 0;
+std::atomic<int> EdgeType::nextId{0};
 
 EdgeType::EdgeType(const vector<FaceData>& fData, const Vec3& direction,
                        const map<string, bool>& options)
@@ -55,7 +57,47 @@ EdgeType* EdgeType::import(const Json& json, Primitives* shape) {
     // I think edge length is only needed for old grammars that have no edgeSettings.
     // result->edgeLength = json["edgeLength"].is_null() ? Util::INF : json["edgeLength"].get<double>();
     result->setSpliced(json["spliced"]);
-    
+
+    return result;
+}
+
+EdgeType* EdgeType::binaryDeserialize(std::istream& in, Primitives* shape) {
+    Vec3 dir = bsReadVec3(in);
+    bool isRigid      = bsRead<uint8_t>(in) != 0;
+    bool isRigidTiled = bsRead<uint8_t>(in) != 0;
+    bool spliced      = bsRead<uint8_t>(in) != 0;
+    string ruleGenId  = bsReadStr(in);
+
+    int32_t fdCount = bsRead<int32_t>(in);
+    vector<FaceData> fData;
+    fData.reserve(fdCount);
+    for (int32_t i = 0; i < fdCount; i++) {
+        int32_t ftIdx = bsRead<int32_t>(in);
+        bool onRight  = bsRead<uint8_t>(in) != 0;
+        fData.push_back({ shape->faceTypes[ftIdx], onRight });
+    }
+
+    map<string, bool> options = { {"isRigid", isRigid}, {"isRigidTiled", isRigidTiled} };
+    auto* result = new EdgeType(fData, dir, options);
+    result->ruleGeneratorId = ruleGenId;
+
+    if (spliced) {
+        result->setSpliced(true); // sets result->spliced and allocates a default EdgeSettings
+    }
+
+    bool hasSettings = bsRead<uint8_t>(in) != 0;
+    if (hasSettings) {
+        delete result->edgeSettings;
+        result->edgeSettings = new EdgeSettings();
+        int32_t n;
+        n = bsRead<int32_t>(in);
+        for (int32_t i = 0; i < n; i++) { auto k = bsReadStr(in); double v = bsRead<double>(in); result->edgeSettings->set(k, v); }
+        n = bsRead<int32_t>(in);
+        for (int32_t i = 0; i < n; i++) { auto k = bsReadStr(in); bool v = bsRead<uint8_t>(in) != 0; result->edgeSettings->set(k, v); }
+        n = bsRead<int32_t>(in);
+        for (int32_t i = 0; i < n; i++) { auto k = bsReadStr(in); auto v = bsReadStr(in); result->edgeSettings->set(k, v); }
+    }
+
     return result;
 }
 
@@ -73,6 +115,10 @@ EdgeSettings* EdgeType::getEdgeSettings() const {
 
 bool EdgeType::getIsRigid() const {
     return isRigid;
+}
+
+bool EdgeType::getIsRigidTiled() const {
+    return isRigidTiled;
 }
 
 bool EdgeType::getSpliced() const {

--- a/cpp_version/primitives/edge_type.cpp
+++ b/cpp_version/primitives/edge_type.cpp
@@ -91,11 +91,23 @@ EdgeType* EdgeType::binaryDeserialize(std::istream& in, Primitives* shape) {
         result->edgeSettings = new EdgeSettings();
         int32_t n;
         n = bsRead<int32_t>(in);
-        for (int32_t i = 0; i < n; i++) { auto k = bsReadStr(in); double v = bsRead<double>(in); result->edgeSettings->set(k, v); }
+        for (int32_t i = 0; i < n; i++) {
+            auto k = bsReadStr(in);
+            double v = bsRead<double>(in);
+            result->edgeSettings->set(k, v);
+        }
         n = bsRead<int32_t>(in);
-        for (int32_t i = 0; i < n; i++) { auto k = bsReadStr(in); bool v = bsRead<uint8_t>(in) != 0; result->edgeSettings->set(k, v); }
+        for (int32_t i = 0; i < n; i++) {
+            auto k = bsReadStr(in);
+            bool v = bsRead<uint8_t>(in) != 0;
+            result->edgeSettings->set(k, v);
+        }
         n = bsRead<int32_t>(in);
-        for (int32_t i = 0; i < n; i++) { auto k = bsReadStr(in); auto v = bsReadStr(in); result->edgeSettings->set(k, v); }
+        for (int32_t i = 0; i < n; i++) {
+            auto k = bsReadStr(in);
+            auto v = bsReadStr(in);
+            result->edgeSettings->set(k, v);
+        }
     }
 
     return result;

--- a/cpp_version/primitives/edge_type.h
+++ b/cpp_version/primitives/edge_type.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <map>
 #include <string>
+#include <iosfwd>
+#include <atomic>
 #include "../geometry/vec3.h"
 #include "primitives.h"
 #include "../graph/edge_settings.h"
@@ -28,11 +30,13 @@ public:
                const map<string, bool>& options = {});
     ~EdgeType() = default;
     static EdgeType* import(const Json& json, Primitives* shape);
+    static EdgeType* binaryDeserialize(std::istream& in, Primitives* shape);
 
     const vector<FaceData>& getFaceData() const;
     const Vec3& getDir() const;
     EdgeSettings* getEdgeSettings() const;
     bool getIsRigid() const;
+    bool getIsRigidTiled() const;
     bool getSpliced() const;
     int getId() const;
 
@@ -54,6 +58,6 @@ private:
     // RuleGenerator string id.
     string ruleGeneratorId;
 
-    static int nextId;
+    static std::atomic<int> nextId;
 };
 

--- a/cpp_version/primitives/face_type.cpp
+++ b/cpp_version/primitives/face_type.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "face_type.h"
 #include "../util/util.h"
+#include "../util/binary_stream.h"
 #include "../geometry/vec2.h"
 #define _USE_MATH_DEFINES
 #include <cmath>
@@ -26,6 +27,15 @@ FaceType* FaceType::import(const Json& json) {
         result->color = Vec3::import(json["color"]);
     }
     
+    return result;
+}
+
+FaceType* FaceType::binaryDeserialize(std::istream& in) {
+    string material = bsReadStr(in);
+    Vec3 normal = bsReadVec3(in);
+    Vec3 color = bsReadVec3(in);
+    auto* result = new FaceType(material, normal);
+    result->color = color;
     return result;
 }
 

--- a/cpp_version/primitives/face_type.h
+++ b/cpp_version/primitives/face_type.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <iosfwd>
 #include "../geometry/vec3.h"
 
 class View;
@@ -16,6 +17,7 @@ public:
     int getMaxDim() const;
 
     static FaceType* import(const Json& json);
+    static FaceType* binaryDeserialize(std::istream& in);
 
 private:
     string material;

--- a/cpp_version/primitives/vertex_type.cpp
+++ b/cpp_version/primitives/vertex_type.cpp
@@ -3,6 +3,7 @@
 #include "edge_type.h"
 #include "primitives.h"
 #include "../util/util.h"
+#include "../util/binary_stream.h"
 
 VertexType::VertexType() : spliced(false), ruleGeneratorId(0) {
 }
@@ -67,4 +68,23 @@ int VertexType::getRuleGeneratorId() const {
 
 void VertexType::setRuleGeneratorId(int id) {
     ruleGeneratorId = id;
+}
+
+VertexType* VertexType::binaryDeserialize(std::istream& in, Primitives* shape) {
+    auto* result = new VertexType();
+    result->spliced         = bsRead<uint8_t>(in) != 0;
+    result->ruleGeneratorId = bsRead<int32_t>(in);
+    int32_t hetCount = bsRead<int32_t>(in);
+    result->halfEdgeTypes.reserve(hetCount);
+    for (int32_t i = 0; i < hetCount; i++) {
+        int32_t etIdx  = bsRead<int32_t>(in);
+        bool isAtStart = bsRead<uint8_t>(in) != 0;
+        Vec3 dir       = bsReadVec3(in);
+        HalfEdgeType het;
+        het.edge      = shape->edgeTypes[etIdx];
+        het.isAtStart = isAtStart;
+        het.dir       = dir;
+        result->halfEdgeTypes.push_back(het);
+    }
+    return result;
 }

--- a/cpp_version/primitives/vertex_type.h
+++ b/cpp_version/primitives/vertex_type.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <iosfwd>
 #include "../geometry/vec2.h"
 #include "edge_type.h"
 #include "primitives.h"
@@ -43,6 +44,7 @@ public:
     VertexType();
     ~VertexType() = default;
     static VertexType* import(const Json& json, Primitives* shape);
+    static VertexType* binaryDeserialize(std::istream& in, Primitives* shape);
 
     const vector<HalfEdgeType>& getHalfEdgeTypes() const;
     bool getSpliced() const;

--- a/cpp_version/util/binary_stream.h
+++ b/cpp_version/util/binary_stream.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <istream>
+#include <ostream>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include "../geometry/vec3.h"
+
+// Primitive write
+template<typename T>
+inline void bsWrite(std::ostream& o, T v) {
+    o.write(reinterpret_cast<const char*>(&v), sizeof(T));
+}
+
+// Primitive read - throws on truncation
+template<typename T>
+inline T bsRead(std::istream& i) {
+    T v{};
+    i.read(reinterpret_cast<char*>(&v), sizeof(T));
+    if (!i) throw std::runtime_error("binary cache read failed");
+    return v;
+}
+
+inline void bsWriteStr(std::ostream& o, const std::string& s) {
+    bsWrite<int32_t>(o, static_cast<int32_t>(s.size()));
+    o.write(s.data(), static_cast<std::streamsize>(s.size()));
+}
+
+inline std::string bsReadStr(std::istream& i) {
+    int32_t n = bsRead<int32_t>(i);
+    if (n < 0 || n > (1 << 20)) throw std::runtime_error("bad string length in cache");
+    std::string s(static_cast<size_t>(n), '\0');
+    if (n > 0) i.read(s.data(), n);
+    return s;
+}
+
+inline void bsWriteVec3(std::ostream& o, const Vec3& v) {
+    bsWrite<double>(o, v.getX());
+    bsWrite<double>(o, v.getY());
+    bsWrite<double>(o, v.getZ());
+}
+
+inline Vec3 bsReadVec3(std::istream& i) {
+    double x = bsRead<double>(i);
+    double y = bsRead<double>(i);
+    double z = bsRead<double>(i);
+    return Vec3(x, y, z);
+}


### PR DESCRIPTION
## Context

When tooling re-loads the same grammar repeatedly (a level editor, an exporter pipeline, a profiling harness), the JSON parse + import path is the dominant cost. For our use case the large grammars take ~50ms to load from JSON each time, and we wanted a way to cache the parsed form to disk so subsequent loads skip the JSON parser entirely.

This PR adds a binary round-trip so `GraphGrammar` can be saved/restored via `std::ostream` / `std::istream`. The on-disk format is private (no version-stability guarantees) — the use case is a cache keyed by source-file mtime where the cache is regenerated on grammar changes.

## What this PR does

- **New** `cpp_version/util/binary_stream.h` — small templated helpers (`bsRead<T>`, `bsWrite<T>`, `bsReadStr` / `bsWriteStr`, `bsReadVec3` / `bsWriteVec3`).
- **New** `GraphGrammar::serialize(std::ostream&) const` and `static GraphGrammar::deserialize(std::istream&)`.
- **New** per-class `binaryDeserialize(...)` methods on `GraphVertex`, `GraphEdge`, `GraphFace`, `GraphHalfEdge`, `Graph`, `ProductionRule`, `VertexType`, `EdgeType`, `FaceType`. The write side stays as static helpers inside `graph_grammar.cpp` since all needed data is already exposed via public getters.
- `EdgeSettings` gains const `getDoubleProperties` / `getBoolProperties` / `getStringProperties` accessors so the serializer can iterate the property maps.
- `EdgeType` gains `getIsRigidTiled()` to mirror `getIsRigid()`; the field already existed, only the accessor was missing.
- Per-class static `nextId` counters become `std::atomic<int>` — same semantics in single-threaded use, but safe for any future parallel allocation paths.

## Why this design

- **Asymmetric serialize/deserialize.** Deserialize needs to allocate instances and set private fields, so it lives on each class as a static factory. Serialize can do everything through public getters and pointer→index maps, so it lives as static helpers in `graph_grammar.cpp` to avoid sprinkling write code across every class.
- **No version header.** The format is intentionally private — the caller is expected to layer a version byte + source mtime on top if they want a persistent cache. Keeping that policy out of the library lets different tools choose their own invalidation strategy.
- **No new dependencies.** Everything is `<istream>` / `<ostream>` / `<cstdint>` / `<string>` / `<atomic>` — no third-party serialization libraries.

## Verification

Built upstream `pmugg.sln` standalone (Release / x64 / MSVC 19.x):

- Smoke baseline — running the existing `pmugg.exe` main against the four bundled grammars produces `Num Faces = 265 / 4 / 64 / 163` for castle / square / house1 / docks, unchanged from main.
- In-memory round-trip — added a temporary harness that does `GraphGrammar::import(json) → serialize → std::stringstream → deserialize → mutator->iterate(100)` and confirmed bit-identical face counts (`265 / 4 / 64 / 163`).

### Benchmark results

Hardware:
```
CPU:   AMD Ryzen 9 9950X3D2 (16C/32T)
RAM:   64 GB DDR5-6000
OS:    Windows 11 Pro 26200
Build: MSVC 19.x, /O2 /MD Release, MSBuild
```

Load-phase timing only (JSON parse + import vs file open + deserialize). Median of 20 runs, warm filesystem.

| Grammar         | JSON load (ms) | Binary load (ms) | Speedup | Binary size (KB) |
|---|---|---|---|---|
| Castle          | 48.60 | 4.99 | **9.74×** | 712.05 |
| Square (Filled) |  0.13 | 0.03 | **4.75×** |   2.10 |
| House 1         |  1.28 | 0.16 | **7.90×** |  24.06 |
| Docks           | 14.34 | 1.54 | **9.32×** | 251.70 |

Smaller grammars get smaller absolute wins (sub-millisecond loads anyway), but the larger ones get an order of magnitude — exactly where it matters. These performance gains are much more noticeable on older hardware (HDD, lower spec all around). I was able to load all grammars from ~40 sec -> ~4 sec on my other 13 year old machine.

## Notes for the maintainer

- No JSON parsing path was modified — `GraphGrammar::import(const Json&)` is untouched, and grammars loaded via the new binary path produce equivalent runtime state.
- Happy to split this into "binary_stream.h + per-class binaryDeserialize" and "GraphGrammar::serialize/deserialize + helpers" as two PRs if you'd prefer; they're conceptually one feature but mechanically separable.
