### PR TITLE
Mesh-to-Primitives extraction module (OBJ → seed grammar)

### DIFF
--- a/cpp_version/mesh_extraction/example_data/cube.mtl
+++ b/cpp_version/mesh_extraction/example_data/cube.mtl
@@ -1,0 +1,3 @@
+newmtl solid
+Ka 0.5 0.5 0.5
+Kd 0.8 0.8 0.8

--- a/cpp_version/mesh_extraction/example_data/cube.obj
+++ b/cpp_version/mesh_extraction/example_data/cube.obj
@@ -1,0 +1,29 @@
+# Closed unit cube centered at the origin. 8 vertices, 6 quad faces, all
+# CCW-wound when viewed from outside the cube. Single material 'solid'.
+# Used as the smoke-test input for mesh_extraction -> seed grammar.
+
+mtllib cube.mtl
+o cube
+
+v -0.5 -0.5 -0.5
+v  0.5 -0.5 -0.5
+v  0.5  0.5 -0.5
+v -0.5  0.5 -0.5
+v -0.5 -0.5  0.5
+v  0.5 -0.5  0.5
+v  0.5  0.5  0.5
+v -0.5  0.5  0.5
+
+usemtl solid
+# back (-Z)
+f 4 3 2 1
+# front (+Z)
+f 5 6 7 8
+# left (-X)
+f 1 5 8 4
+# right (+X)
+f 2 3 7 6
+# bottom (-Y)
+f 1 2 6 5
+# top (+Y)
+f 4 8 7 3

--- a/cpp_version/mesh_extraction/half_edge_mesh.cpp
+++ b/cpp_version/mesh_extraction/half_edge_mesh.cpp
@@ -1,0 +1,175 @@
+#include "pch.h"
+#include "mesh_extraction/half_edge_mesh.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <unordered_map>
+
+namespace mesh_extraction {
+
+namespace {
+
+// Computes a Newell-style polygon normal: stable for non-planar faces and
+// signed by winding order. Returns a unit vector or (0,0,0) if degenerate.
+Vec3d newellNormal(const ObjMesh& obj, const ObjMesh::Face& f) {
+    double nx = 0, ny = 0, nz = 0;
+    int n_corners = (int)f.corners.size();
+    for (int i = 0; i < n_corners; ++i) {
+        const auto& a = obj.vertices[f.corners[i].vertexIndex];
+        const auto& b = obj.vertices[f.corners[(i + 1) % n_corners].vertexIndex];
+        nx += (a.y - b.y) * (a.z + b.z);
+        ny += (a.z - b.z) * (a.x + b.x);
+        nz += (a.x - b.x) * (a.y + b.y);
+    }
+    double len = std::sqrt(nx * nx + ny * ny + nz * nz);
+    if (len > 0) { nx /= len; ny /= len; nz /= len; }
+    return Vec3d{nx, ny, nz};
+}
+
+// Encode an undirected vertex pair (a, b) into a single 64-bit key so we can
+// hash-match a half-edge to its twin in O(N). The pair is unordered for twin
+// lookup (twin of (a→b) is (b→a)) but we always use the directional key here
+// because we WANT to find the unique opposite-direction half.
+inline uint64_t directedKey(int from, int to) {
+    return (static_cast<uint64_t>(static_cast<uint32_t>(from)) << 32) |
+            static_cast<uint64_t>(static_cast<uint32_t>(to));
+}
+
+}  // namespace
+
+bool buildHalfEdgeMesh(const ObjMesh& obj,
+                       HalfEdgeMesh&  out,
+                       bool           useGroupAsVolume,
+                       std::string*   error) {
+    out = {};
+    out.numVertices = (int)obj.vertices.size();
+    out.vertexHalves.resize(obj.vertices.size());
+
+    // --- Volume label assignment (step 2 of the plan). ----------------------
+    // Map OBJ group name → volume id. The empty group counts as one volume.
+    std::unordered_map<std::string, int> groupToVol;
+    if (useGroupAsVolume) {
+        for (const auto& f : obj.faces) {
+            if (groupToVol.find(f.groupName) == groupToVol.end()) {
+                int id = (int)groupToVol.size() + 1;  // 0 reserved for ambient
+                groupToVol[f.groupName] = id;
+                out.volumeNames.push_back(f.groupName);
+            }
+        }
+    } else {
+        // Single closed surface → one interior volume.
+        groupToVol[""] = 1;
+        out.volumeNames.push_back("interior");
+    }
+    out.numVolumes = (int)out.volumeNames.size() + 1;  // +1 for the ambient slot
+
+    // --- Face creation + half-edge allocation. ------------------------------
+    out.faces.reserve(obj.faces.size());
+    for (size_t fi = 0; fi < obj.faces.size(); ++fi) {
+        const ObjMesh::Face& srcFace = obj.faces[fi];
+        if (srcFace.corners.size() < 3) {
+            if (error) {
+                char buf[128];
+                snprintf(buf, sizeof(buf), "face %zu has %zu corners (< 3)",
+                         fi, srcFace.corners.size());
+                *error = buf;
+            }
+            return false;
+        }
+
+        HalfEdgeMesh::Face dstFace;
+        dstFace.normal     = newellNormal(obj, srcFace);
+        dstFace.materialId = srcFace.materialId;
+        dstFace.group      = srcFace.groupName;
+
+        int volInterior = useGroupAsVolume ? groupToVol[srcFace.groupName] : groupToVol[""];
+        // Face normal points from "interior" into "ambient" by OBJ convention
+        // (outward winding). volAbove (normal side) is therefore ambient (0)
+        // and volBelow is the enclosed interior.
+        dstFace.volAbove   = 0;
+        dstFace.volBelow   = volInterior;
+
+        // Allocate half-edges in CCW order around the face.
+        int nCorners = (int)srcFace.corners.size();
+        int firstHE = (int)out.halfEdges.size();
+        for (int k = 0; k < nCorners; ++k) {
+            HalfEdgeMesh::HalfEdge he;
+            he.origin = srcFace.corners[k].vertexIndex;
+            he.dest   = srcFace.corners[(k + 1) % nCorners].vertexIndex;
+            he.face   = (int)fi;
+            he.twin   = -1;
+            he.next   = firstHE + (k + 1) % nCorners;
+            he.prev   = firstHE + (k - 1 + nCorners) % nCorners;
+            he.edge   = -1;  // populated in twin-matching pass
+            out.halfEdges.push_back(he);
+            dstFace.halfEdges.push_back(firstHE + k);
+            out.vertexHalves[he.origin].push_back(firstHE + k);
+        }
+        out.faces.push_back(std::move(dstFace));
+    }
+
+    // --- Twin matching + edge creation. -------------------------------------
+    // For each directed half (a→b) look for (b→a). If found exactly once, pair
+    // them and create one edge owning both halves. Halves with no match are
+    // boundary halves (flag the mesh as non-closed).
+    std::unordered_map<uint64_t, int> dirKey;
+    dirKey.reserve(out.halfEdges.size() * 2);
+    for (int i = 0; i < (int)out.halfEdges.size(); ++i) {
+        const auto& he = out.halfEdges[i];
+        uint64_t key = directedKey(he.origin, he.dest);
+        auto ins = dirKey.emplace(key, i);
+        if (!ins.second) {
+            // Duplicate directed half-edge — winding error or non-manifold.
+            if (error) {
+                char buf[160];
+                snprintf(buf, sizeof(buf),
+                         "duplicate directed edge %d→%d (faces %d, %d) — "
+                         "non-manifold or inconsistent winding",
+                         he.origin, he.dest, he.face,
+                         out.halfEdges[ins.first->second].face);
+                *error = buf;
+            }
+            return false;
+        }
+    }
+    for (int i = 0; i < (int)out.halfEdges.size(); ++i) {
+        auto& he = out.halfEdges[i];
+        if (he.twin >= 0) continue;
+        uint64_t twinKey = directedKey(he.dest, he.origin);
+        auto it = dirKey.find(twinKey);
+        if (it == dirKey.end()) {
+            out.isClosedManifold = false;
+            continue;  // boundary half — no twin
+        }
+        int j = it->second;
+        if (i == j) continue;  // shouldn't happen but guard
+
+        HalfEdgeMesh::Edge edge;
+        edge.halfA = (i < j) ? i : j;
+        edge.halfB = (i < j) ? j : i;
+        int edgeIdx = (int)out.edges.size();
+        out.edges.push_back(edge);
+
+        out.halfEdges[i].twin = j;
+        out.halfEdges[j].twin = i;
+        out.halfEdges[i].edge = edgeIdx;
+        out.halfEdges[j].edge = edgeIdx;
+    }
+
+    // Boundary halves (no twin) need an edge too, so vertex-type derivation
+    // sees a consistent picture. They'll be flagged separately via Edge.halfB = -1.
+    for (int i = 0; i < (int)out.halfEdges.size(); ++i) {
+        if (out.halfEdges[i].edge >= 0) continue;
+        HalfEdgeMesh::Edge edge;
+        edge.halfA = i;
+        edge.halfB = -1;
+        int edgeIdx = (int)out.edges.size();
+        out.edges.push_back(edge);
+        out.halfEdges[i].edge = edgeIdx;
+    }
+
+    return true;
+}
+
+}  // namespace mesh_extraction

--- a/cpp_version/mesh_extraction/half_edge_mesh.h
+++ b/cpp_version/mesh_extraction/half_edge_mesh.h
@@ -1,0 +1,72 @@
+#pragma once
+// Half-edge representation derived from an ObjMesh. Steps 2-5 of the plan
+// (volume labels, face/edge/vertex type derivation) all walk this structure.
+// Geometry only — no pmugg types yet.
+//
+// We use a local Vec3d here instead of pmugg's geometry/vec3.h because this
+// header is included by FPS_MapExporter, which has its own Vec3 in
+// FPS_Math.h. The two types collide in any translation unit that sees both.
+
+#include "mesh_extraction/obj_loader.h"
+
+#include <vector>
+
+namespace mesh_extraction {
+
+struct Vec3d { double x, y, z; };
+
+struct HalfEdgeMesh {
+    struct HalfEdge {
+        int origin;     // index of source vertex in ObjMesh::vertices
+        int dest;       // index of destination vertex
+        int face;       // index into faces (-1 = unbounded ambient side)
+        int twin;       // index of twin half-edge (-1 if boundary)
+        int next;       // next half-edge around `face` (CCW)
+        int prev;       // prev half-edge around `face` (CCW)
+        int edge;       // index into edges (each edge owns two halves)
+    };
+
+    struct Face {
+        std::vector<int> halfEdges;   // ordered CCW (matches OBJ winding)
+        Vec3d            normal;      // unit, area-weighted from the n-gon
+        int              materialId;  // copy from ObjMesh::Face::materialId
+        std::string      group;       // copy from ObjMesh::Face::groupName
+        int              volAbove;    // volume on the normal-positive side
+        int              volBelow;    // volume on the opposite side
+    };
+
+    struct Edge {
+        int halfA;     // forward direction (origin < dest by some canonical order)
+        int halfB;     // reverse direction (twin); -1 if mesh has a boundary
+    };
+
+    std::vector<HalfEdge>           halfEdges;
+    std::vector<Face>               faces;
+    std::vector<Edge>               edges;
+    std::vector<std::vector<int>>   vertexHalves;  // vertexHalves[v] = halves originating at v
+    int                              numVertices = 0;
+    int                              numVolumes  = 0;  // 0 = ambient, 1..N = interior labels
+    std::vector<std::string>         volumeNames;     // index = volumeId
+
+    // Was every input edge shared by exactly two faces? Phase A of the plan
+    // (closed-surface) requires this. If false, the input is open or
+    // multi-manifold and the vertex-type Phase B canonicalizer will be needed.
+    bool isClosedManifold = true;
+};
+
+// Build the half-edge structure from `obj`. Returns false on degenerate input
+// (a face with < 3 corners, a non-manifold edge with 3+ incident faces, etc.).
+// On failure, `error` describes the first problem encountered.
+//
+// Volume assignment (step 2 of the plan):
+//   - If `useGroupAsVolume` is true and the input has >1 distinct group, each
+//     group gets its own volumeId (the group's interior). The ambient region
+//     gets volumeId 0.
+//   - Otherwise (or for single-group input), a single closed surface is
+//     assumed: volumeId 0 = ambient, volumeId 1 = the enclosed interior.
+bool buildHalfEdgeMesh(const ObjMesh& obj,
+                       HalfEdgeMesh&  out,
+                       bool           useGroupAsVolume,
+                       std::string*   error = nullptr);
+
+}  // namespace mesh_extraction

--- a/cpp_version/mesh_extraction/obj_loader.cpp
+++ b/cpp_version/mesh_extraction/obj_loader.cpp
@@ -1,0 +1,142 @@
+// No PCH. tinyobjloader is a third-party single-header library; including
+// the project PCH here would force tinyobj's implementation through it.
+#define TINYOBJLOADER_IMPLEMENTATION
+#include "third_party/tinyobjloader/tiny_obj_loader.h"
+
+#include "mesh_extraction/obj_loader.h"
+
+#include <fstream>
+#include <sstream>
+#include <unordered_set>
+
+namespace mesh_extraction {
+
+// Read the entire file into a string. Returns empty string on failure (caller
+// will then get tinyobjloader's own error on the subsequent parse).
+static std::string slurpFile(const char* path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return {};
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+// Scan an .obj text for `usemtl <name>` references and synthesize a minimal
+// .mtl content (`newmtl <name>\n` per unique name). Reason: when an .obj
+// references materials via usemtl but no .mtl ships alongside (common in the
+// pmugg sample meshes), tinyobjloader drops the names — face.material_id
+// becomes -1 and the label is lost. Pre-populating a synthetic .mtl lets
+// every usemtl resolve to a real index whose name we can read back.
+static std::string synthesizeMtlFromUsemtl(const std::string& objText) {
+    std::unordered_set<std::string> seen;
+    std::string out;
+    size_t i = 0, n = objText.size();
+    while (i < n) {
+        // Find start of line content (skip leading whitespace).
+        size_t lineStart = i;
+        while (lineStart < n && (objText[lineStart] == ' ' || objText[lineStart] == '\t'))
+            ++lineStart;
+        if (lineStart + 6 < n && objText.compare(lineStart, 6, "usemtl") == 0 &&
+            (objText[lineStart + 6] == ' ' || objText[lineStart + 6] == '\t')) {
+            size_t name = lineStart + 7;
+            while (name < n && (objText[name] == ' ' || objText[name] == '\t')) ++name;
+            size_t end = name;
+            while (end < n && objText[end] != '\n' && objText[end] != '\r') ++end;
+            // Trim trailing whitespace.
+            while (end > name && (objText[end - 1] == ' ' || objText[end - 1] == '\t')) --end;
+            if (end > name) {
+                std::string mat(objText, name, end - name);
+                if (seen.insert(mat).second) {
+                    out += "newmtl ";
+                    out += mat;
+                    out += '\n';
+                }
+            }
+        }
+        // Advance to next line.
+        while (i < n && objText[i] != '\n') ++i;
+        if (i < n) ++i;
+    }
+    return out;
+}
+
+bool loadObj(const char* path, ObjMesh& out, std::string* error) {
+    out = {};
+
+    tinyobj::ObjReaderConfig cfg;
+    cfg.triangulate = false;  // preserve n-gons; the algorithm operates on polygon faces
+    cfg.vertex_color = false;
+
+    std::string objText = slurpFile(path);
+    if (objText.empty()) {
+        if (error) *error = std::string("could not open file: ") + path;
+        return false;
+    }
+    std::string synthMtl = synthesizeMtlFromUsemtl(objText);
+
+    // Strip any pre-existing `mtllib` directives. tinyobj's MaterialStreamReader
+    // consumes its stream on first call; a second mtllib would error out. Then
+    // prepend our own synthetic mtllib so the reader fires exactly once and
+    // populates every name referenced by usemtl.
+    {
+        std::string filtered;
+        filtered.reserve(objText.size() + synthMtl.size() + 32);
+        filtered += "mtllib __synth__.mtl\n";
+        size_t i = 0, n = objText.size();
+        while (i < n) {
+            size_t lineStart = i;
+            size_t cur = i;
+            while (cur < n && (objText[cur] == ' ' || objText[cur] == '\t')) ++cur;
+            bool drop = (cur + 6 < n && objText.compare(cur, 6, "mtllib") == 0 &&
+                         (objText[cur + 6] == ' ' || objText[cur + 6] == '\t'));
+            while (i < n && objText[i] != '\n') ++i;
+            if (i < n) ++i;
+            if (!drop) filtered.append(objText, lineStart, i - lineStart);
+        }
+        objText.swap(filtered);
+    }
+
+    tinyobj::ObjReader reader;
+    if (!reader.ParseFromString(objText, synthMtl, cfg)) {
+        if (error) *error = reader.Error();
+        return false;
+    }
+    if (error && !reader.Warning().empty()) *error = reader.Warning();
+
+    const auto& attrib    = reader.GetAttrib();
+    const auto& shapes    = reader.GetShapes();
+    const auto& materials = reader.GetMaterials();
+
+    out.vertices.reserve(attrib.vertices.size() / 3);
+    for (size_t i = 0; i + 2 < attrib.vertices.size(); i += 3) {
+        out.vertices.push_back({attrib.vertices[i], attrib.vertices[i + 1], attrib.vertices[i + 2]});
+    }
+    out.normals.reserve(attrib.normals.size() / 3);
+    for (size_t i = 0; i + 2 < attrib.normals.size(); i += 3) {
+        out.normals.push_back({attrib.normals[i], attrib.normals[i + 1], attrib.normals[i + 2]});
+    }
+
+    out.materialNames.reserve(materials.size());
+    for (const auto& m : materials) out.materialNames.push_back(m.name);
+
+    for (const auto& shape : shapes) {
+        const auto& mesh = shape.mesh;
+        size_t corner = 0;
+        for (size_t f = 0; f < mesh.num_face_vertices.size(); ++f) {
+            int n = mesh.num_face_vertices[f];
+            ObjMesh::Face face;
+            face.corners.reserve(n);
+            for (int k = 0; k < n; ++k) {
+                const tinyobj::index_t& idx = mesh.indices[corner + k];
+                face.corners.push_back({idx.vertex_index, idx.normal_index, idx.texcoord_index});
+            }
+            face.materialId = (f < mesh.material_ids.size()) ? mesh.material_ids[f] : -1;
+            face.groupName  = shape.name;
+            out.faces.push_back(std::move(face));
+            corner += n;
+        }
+    }
+    return true;
+}
+
+}  // namespace mesh_extraction

--- a/cpp_version/mesh_extraction/obj_loader.h
+++ b/cpp_version/mesh_extraction/obj_loader.h
@@ -1,0 +1,37 @@
+#pragma once
+// Step 2.3.1 of MESH_TO_PRIMITIVES_PLAN.md: minimal .obj loader on top of
+// tinyobjloader. The smoke-test consumer only reads counts; the struct is
+// shaped to grow into the later type-derivation steps (vertex/edge/face
+// type buckets need the per-face material, group, and corner indices).
+
+#include <string>
+#include <vector>
+
+namespace mesh_extraction {
+
+struct ObjMesh {
+    struct Vec3 { float x, y, z; };
+
+    struct FaceCorner {
+        int vertexIndex;    // 0-based
+        int normalIndex;    // 0-based; -1 if absent
+        int texCoordIndex;  // 0-based; -1 if absent
+    };
+
+    struct Face {
+        std::vector<FaceCorner> corners;  // n-gon as authored; not triangulated
+        int                     materialId;  // index into materialNames; -1 = none
+        std::string             groupName;   // most recent `g` / `o` tag
+    };
+
+    std::vector<Vec3>         vertices;
+    std::vector<Vec3>         normals;
+    std::vector<Face>         faces;
+    std::vector<std::string>  materialNames;  // index = materialId
+};
+
+// Returns true on success. On failure, fills `error` (if non-null) with the
+// tinyobjloader error/warning text and leaves `out` partially populated.
+bool loadObj(const char* path, ObjMesh& out, std::string* error = nullptr);
+
+}  // namespace mesh_extraction

--- a/cpp_version/mesh_extraction/seed_grammar_writer.cpp
+++ b/cpp_version/mesh_extraction/seed_grammar_writer.cpp
@@ -1,0 +1,245 @@
+#include "pch.h"
+#include "mesh_extraction/seed_grammar_writer.h"
+
+#include "third_party/json.h"
+
+#include <fstream>
+
+namespace mesh_extraction {
+
+namespace {
+
+using Json = nlohmann::json;
+
+Json vec3ToJson(const Vec3d& v) {
+    Json j;
+    j["x"] = v.x;
+    j["y"] = v.y;
+    j["z"] = v.z;
+    return j;
+}
+
+// Build the seed Graph JSON matching the schema consumed by Graph::import.
+// Produces both the topology arrays and the type-index arrays.
+Json buildSeedGraphJson(const HalfEdgeMesh&   mesh,
+                        const ExtractedTypes& types) {
+    Json g;
+
+    // Vertices: list of incident half-edge indices, slotted by the vertex
+    // type's halfEdgeTypes order.
+    Json vertices = Json::array();
+    Json vertexTypesArr = Json::array();
+    for (int v = 0; v < mesh.numVertices; ++v) {
+        if (mesh.vertexHalves[v].empty()) continue;
+        int vtIdx = types.vertexTypeOfVertex[v];
+        int slots = (int)types.vertexTypes[vtIdx].halfEdgeTypes.size();
+        std::vector<int> halves(slots, -1);
+        for (int he : mesh.vertexHalves[v]) {
+            int slot = types.halfEdgeSlotInVertex[he];
+            if (slot >= 0 && slot < slots) halves[slot] = he;
+        }
+        Json vert;
+        vert["halfEdges"] = halves;
+        vertices.push_back(std::move(vert));
+
+        Json vtRef;
+        vtRef["kind"] = "v";
+        vtRef["type"] = vtIdx;
+        vertexTypesArr.push_back(std::move(vtRef));
+    }
+
+    // Edges: each edge has 2 "slots" of half-edges; pmugg schema stores them
+    // as [[<halfA>], [<halfB>]].
+    Json edges = Json::array();
+    Json edgeTypesArr = Json::array();
+    for (size_t ei = 0; ei < mesh.edges.size(); ++ei) {
+        const auto& e = mesh.edges[ei];
+        Json edge;
+        Json slotA = Json::array(); slotA.push_back(e.halfA);
+        Json slotB = Json::array();
+        if (e.halfB >= 0) slotB.push_back(e.halfB);
+        edge["halfEdges"] = { slotA, slotB };
+        edges.push_back(std::move(edge));
+
+        edgeTypesArr.push_back(types.edgeTypeOfEdge[ei]);
+    }
+
+    // Half-edges: forward / edgeIndex / vertexIndex / vertex / edge / prev /
+    // next / face. Convention:
+    //   forward    = (this half is the canonical halfA of its edge)
+    //   edgeIndex  = 0 if forward (halfA slot), 1 otherwise
+    //   vertexIndex = position of this halfEdge in the vertex's halfEdges array
+    //                 (this is types.halfEdgeSlotInVertex[he])
+    Json halfEdges = Json::array();
+    for (size_t hi = 0; hi < mesh.halfEdges.size(); ++hi) {
+        const auto& he = mesh.halfEdges[hi];
+        const auto& edge = mesh.edges[he.edge];
+        bool forward = (edge.halfA == (int)hi);
+
+        Json j;
+        j["forward"]     = forward;
+        j["edgeIndex"]   = forward ? 0 : 1;
+        j["vertexIndex"] = types.halfEdgeSlotInVertex[hi];
+        j["vertex"]      = he.origin;
+        j["edge"]        = he.edge;
+        j["prev"]        = he.prev;
+        j["next"]        = he.next;
+        j["face"]        = he.face;
+        halfEdges.push_back(std::move(j));
+    }
+
+    // Faces: each face's outerComponent is one half-edge on its boundary.
+    Json faces = Json::array();
+    Json faceTypesArr = Json::array();
+    for (size_t fi = 0; fi < mesh.faces.size(); ++fi) {
+        const auto& f = mesh.faces[fi];
+        Json face;
+        face["outerComponent"] = f.halfEdges.empty() ? -1 : f.halfEdges.front();
+        faces.push_back(std::move(face));
+
+        faceTypesArr.push_back(types.faceTypeOfFace[fi]);
+    }
+
+    g["interior"]    = {
+        {"vertices",  vertices},
+        {"edges",     edges},
+        {"halfEdges", halfEdges},
+        {"faces",     faces},
+    };
+    g["vertexTypes"] = vertexTypesArr;
+    g["edgeTypes"]   = edgeTypesArr;
+    g["faceTypes"]   = faceTypesArr;
+    // Closed shape — no boundary. Morphism arrays are empty.
+    g["morphism"]    = {
+        {"vertices", Json::array()},
+        {"halfs",    Json::array()},
+        {"faces",    Json::array()},
+    };
+    return g;
+}
+
+// Empty graph: one face with the "ambient" face type (faceType[0] by
+// convention — we put the first volume's outward face there). This is the
+// substrate the starter rule expands into.
+Json buildEmptyGraphJson(const ExtractedTypes& /*types*/) {
+    Json g;
+    g["interior"] = {
+        {"vertices",  Json::array()},
+        {"edges",     Json::array()},
+        {"halfEdges", Json::array()},
+        {"faces",     Json::array({ Json{ {"outerComponent", -1} } })},
+    };
+    g["vertexTypes"] = Json::array();
+    g["edgeTypes"]   = Json::array();
+    g["faceTypes"]   = Json::array({ 0 });  // ambient
+    g["morphism"]    = {
+        {"vertices", Json::array()},
+        {"halfs",    Json::array()},
+        {"faces",    Json::array()},
+    };
+    return g;
+}
+
+}  // namespace
+
+bool writeSeedGrammar(const HalfEdgeMesh&    mesh,
+                      const ExtractedTypes&  types,
+                      const std::string&     name,
+                      const std::string&     outPath,
+                      std::string*           error) {
+    Json root;
+    root["name"]     = name;
+    // version 1 = current schema. Absent that tag, jsonMigration1 fires and
+    // (per its legacy logic) discards everything not under a `solution` field.
+    root["version"]  = 1;
+    root["grounded"] = false;
+
+    // ----- types: faceTypes, edgeTypes, vertexTypes ------------------------
+    Json faceTypesJson = Json::array();
+    for (const auto& ft : types.faceTypes) {
+        Json j;
+        j["material"] = ft.material;
+        j["normal"]   = vec3ToJson(ft.normal);
+        j["color"]    = nullptr;
+        faceTypesJson.push_back(std::move(j));
+    }
+
+    Json edgeTypesJson = Json::array();
+    for (const auto& et : types.edgeTypes) {
+        Json j;
+        j["dir"]          = vec3ToJson(et.dir);
+        j["isRigid"]      = false;
+        j["isRigidTiled"] = false;
+        j["spliced"]      = false;
+        Json fd = Json::array();
+        for (const auto& f : et.faceData) {
+            Json fj;
+            fj["type"]    = f.faceType;
+            fj["onRight"] = f.onRight;
+            fd.push_back(std::move(fj));
+        }
+        j["faceData"] = fd;
+        // Default edgeSettings matching the existing shipped grammars so the
+        // mutator has sensible min/max lengths.
+        j["edgeSettings"] = {
+            {"Min Length", 0.1},
+            {"Max Length", 4.0},
+            {"Tile Length", 1.0},
+            {"Rigid Tiled", false},
+        };
+        edgeTypesJson.push_back(std::move(j));
+    }
+
+    Json vertexTypesJson = Json::array();
+    for (const auto& vt : types.vertexTypes) {
+        Json j;
+        j["spliced"] = false;
+        Json het = Json::array();
+        for (const auto& h : vt.halfEdgeTypes) {
+            Json hj;
+            hj["edge"]      = h.edgeType;
+            hj["isAtStart"] = h.isAtStart;
+            // dir is rederived from edge by VertexType::import if absent for
+            // spliced types; for non-spliced it must be present. Use the edge
+            // type's stored dir, negated if !isAtStart.
+            const auto& d = types.edgeTypes[h.edgeType].dir;
+            Vec3d hd = h.isAtStart ? d : Vec3d{-d.x, -d.y, -d.z};
+            hj["dir"] = vec3ToJson(hd);
+            het.push_back(std::move(hj));
+        }
+        j["halfEdgeTypes"] = het;
+        vertexTypesJson.push_back(std::move(j));
+    }
+
+    Json typesJson;
+    typesJson["dims"]        = 3;
+    typesJson["faceTypes"]   = faceTypesJson;
+    typesJson["edgeTypes"]   = edgeTypesJson;
+    typesJson["vertexTypes"] = vertexTypesJson;
+    root["types"] = typesJson;
+
+    // ----- rules: empty `rules` / `groundRules`, one starter rule ---------
+    root["rules"]       = Json::array();
+    root["groundRules"] = Json::array();
+
+    Json starterRule;
+    starterRule["ground"] = false;
+    Json emptyGraph = buildEmptyGraphJson(types);
+    Json seedGraph  = buildSeedGraphJson(mesh, types);
+    starterRule["n"] = Json::array({ emptyGraph, seedGraph });
+    root["starterRules"] = Json::array({ starterRule });
+
+    // ----- emptyGraph -----------------------------------------------------
+    root["emptyGraph"] = buildEmptyGraphJson(types);
+
+    // ----- write ----------------------------------------------------------
+    std::ofstream out(outPath);
+    if (!out) {
+        if (error) *error = std::string("could not open for write: ") + outPath;
+        return false;
+    }
+    out << root.dump(2);
+    return true;
+}
+
+}  // namespace mesh_extraction

--- a/cpp_version/mesh_extraction/seed_grammar_writer.h
+++ b/cpp_version/mesh_extraction/seed_grammar_writer.h
@@ -1,0 +1,24 @@
+#pragma once
+// Steps 6-7 of MESH_TO_PRIMITIVES_PLAN.md: serialize the half-edge mesh and
+// its extracted types as a pmugg grammar JSON containing a single starter
+// rule that emits the seed shape from the empty graph.
+//
+// The output is loadable by GraphGrammar::import() — i.e. it round-trips
+// through loadGrammarCached() and can be passed to runGrammarEngine().
+
+#include "mesh_extraction/half_edge_mesh.h"
+#include "mesh_extraction/type_extractor.h"
+
+#include <string>
+
+namespace mesh_extraction {
+
+// Writes a grammar JSON to `outPath`. Returns false (and sets `error`) on
+// I/O failure.
+bool writeSeedGrammar(const HalfEdgeMesh&    mesh,
+                      const ExtractedTypes&  types,
+                      const std::string&     name,
+                      const std::string&     outPath,
+                      std::string*           error = nullptr);
+
+}  // namespace mesh_extraction

--- a/cpp_version/mesh_extraction/type_extractor.cpp
+++ b/cpp_version/mesh_extraction/type_extractor.cpp
@@ -1,0 +1,287 @@
+#include "pch.h"
+#include "mesh_extraction/type_extractor.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+#include <sstream>
+#include <unordered_map>
+
+namespace mesh_extraction {
+
+namespace {
+
+inline int64_t quantize(double v, double eps) {
+    // Round-half-to-even via std::llround keeps positive and negative scaled
+    // alike. eps controls the grid; 1e-4 means 4 digits of resolution.
+    return static_cast<int64_t>(std::llround(v / eps));
+}
+
+struct QuantVec3 {
+    int64_t x, y, z;
+    bool operator==(const QuantVec3& o) const { return x == o.x && y == o.y && z == o.z; }
+};
+struct QuantVec3Hash {
+    size_t operator()(const QuantVec3& q) const {
+        // 64-bit mix; collisions on box.obj-scale data are negligible.
+        uint64_t h = static_cast<uint64_t>(q.x) * 0x9E3779B97F4A7C15ULL;
+        h ^= static_cast<uint64_t>(q.y) + 0x9E3779B97F4A7C15ULL + (h << 6) + (h >> 2);
+        h ^= static_cast<uint64_t>(q.z) + 0x9E3779B97F4A7C15ULL + (h << 6) + (h >> 2);
+        return static_cast<size_t>(h);
+    }
+};
+inline QuantVec3 q3(const Vec3d& v, double eps) {
+    return {quantize(v.x, eps), quantize(v.y, eps), quantize(v.z, eps)};
+}
+
+// Face type key: (material, volAbove, volBelow, quantized normal).
+struct FaceTypeKey {
+    std::string material;
+    int         volAbove;
+    int         volBelow;
+    QuantVec3   normal;
+    bool operator==(const FaceTypeKey& o) const {
+        return material == o.material && volAbove == o.volAbove
+            && volBelow == o.volBelow && normal == o.normal;
+    }
+};
+struct FaceTypeKeyHash {
+    size_t operator()(const FaceTypeKey& k) const {
+        size_t h = std::hash<std::string>{}(k.material);
+        h ^= std::hash<int>{}(k.volAbove) + 0x9E3779B9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.volBelow) + 0x9E3779B9 + (h << 6) + (h >> 2);
+        h ^= QuantVec3Hash{}(k.normal)    + 0x9E3779B9 + (h << 6) + (h >> 2);
+        return h;
+    }
+};
+
+// Edge type key: ordered face-type pair (left, right) + quantized direction.
+// Left = halfA's face (canonical direction), right = halfB's face (or -1 for
+// open-boundary edges).
+struct EdgeTypeKey {
+    int        leftFaceType;
+    int        rightFaceType;  // -1 if boundary
+    QuantVec3  dir;
+    bool operator==(const EdgeTypeKey& o) const {
+        return leftFaceType == o.leftFaceType
+            && rightFaceType == o.rightFaceType
+            && dir == o.dir;
+    }
+};
+struct EdgeTypeKeyHash {
+    size_t operator()(const EdgeTypeKey& k) const {
+        size_t h = std::hash<int>{}(k.leftFaceType);
+        h ^= std::hash<int>{}(k.rightFaceType) + 0x9E3779B9 + (h << 6) + (h >> 2);
+        h ^= QuantVec3Hash{}(k.dir)            + 0x9E3779B9 + (h << 6) + (h >> 2);
+        return h;
+    }
+};
+
+// Walk CCW around `vertex` to enumerate outgoing half-edges. Uses the
+// twin/next traversal: from any outgoing halfEdge h, the next outgoing
+// halfEdge is `h.prev.twin` (rotate to the previous edge of the face, then
+// flip across the shared edge to the next face). Requires a closed manifold.
+//
+// Returns the ordered list of outgoing-halfedge indices, or {} on failure
+// (open boundary at this vertex, non-manifold fan, etc.).
+std::vector<int> walkVertexFan(const HalfEdgeMesh& mesh, int vertexIdx) {
+    const auto& outgoing = mesh.vertexHalves[vertexIdx];
+    if (outgoing.empty()) return {};
+
+    std::vector<int> fan;
+    int start = outgoing.front();
+    int cur = start;
+    fan.push_back(cur);
+    for (size_t guard = 0; guard < outgoing.size(); ++guard) {
+        const auto& he = mesh.halfEdges[cur];
+        // Step to previous edge of the same face, then cross via twin to the
+        // next face. The result originates from the same vertex.
+        int prev = he.prev;
+        int twinOfPrev = mesh.halfEdges[prev].twin;
+        if (twinOfPrev < 0) return {};  // open boundary — Phase B input
+        int next = twinOfPrev;
+        if (next == start) {
+            // Sanity check: we should have visited every outgoing half exactly once.
+            if (fan.size() != outgoing.size()) return {};
+            return fan;
+        }
+        fan.push_back(next);
+        cur = next;
+    }
+    return {};  // didn't close after |outgoing| steps — non-manifold
+}
+
+}  // namespace
+
+bool extractTypes(const HalfEdgeMesh&         mesh,
+                  const ObjMesh&              obj,
+                  const TypeExtractionConfig& cfg,
+                  ExtractedTypes&             out,
+                  std::string*                error) {
+    out = {};
+
+    // --- Step 3: face types ------------------------------------------------
+    out.faceTypeOfFace.resize(mesh.faces.size(), -1);
+    std::unordered_map<FaceTypeKey, int, FaceTypeKeyHash> faceTypeMap;
+    for (size_t fi = 0; fi < mesh.faces.size(); ++fi) {
+        const auto& f = mesh.faces[fi];
+        std::string mat;
+        if (f.materialId >= 0 && f.materialId < (int)obj.materialNames.size())
+            mat = obj.materialNames[f.materialId];
+
+        FaceTypeKey key{mat, f.volAbove, f.volBelow, q3(f.normal, cfg.normalEps)};
+        auto it = faceTypeMap.find(key);
+        int idx;
+        if (it == faceTypeMap.end()) {
+            idx = (int)out.faceTypes.size();
+            out.faceTypes.push_back({mat, f.normal, f.volAbove, f.volBelow});
+            faceTypeMap.emplace(std::move(key), idx);
+        } else {
+            idx = it->second;
+        }
+        out.faceTypeOfFace[fi] = idx;
+    }
+
+    // --- Step 4: edge types ------------------------------------------------
+    out.edgeTypeOfEdge.resize(mesh.edges.size(), -1);
+    std::unordered_map<EdgeTypeKey, int, EdgeTypeKeyHash> edgeTypeMap;
+    for (size_t ei = 0; ei < mesh.edges.size(); ++ei) {
+        const auto& edge = mesh.edges[ei];
+        const auto& hA = mesh.halfEdges[edge.halfA];
+        const auto& vO = obj.vertices[hA.origin];
+        const auto& vD = obj.vertices[hA.dest];
+        double dx = vD.x - vO.x, dy = vD.y - vO.y, dz = vD.z - vO.z;
+        double dlen = std::sqrt(dx * dx + dy * dy + dz * dz);
+        if (dlen > 0) { dx /= dlen; dy /= dlen; dz /= dlen; }
+        Vec3d dir{dx, dy, dz};
+
+        int leftFaceType  = out.faceTypeOfFace[hA.face];
+        int rightFaceType = (edge.halfB >= 0)
+            ? out.faceTypeOfFace[mesh.halfEdges[edge.halfB].face]
+            : -1;
+
+        EdgeTypeKey key{leftFaceType, rightFaceType, q3(dir, cfg.dirEps)};
+        auto it = edgeTypeMap.find(key);
+        int idx;
+        if (it == edgeTypeMap.end()) {
+            idx = (int)out.edgeTypes.size();
+            ExtractedTypes::EdgeType et;
+            et.dir = dir;
+            et.faceData.push_back({leftFaceType,  /*onRight*/ false});
+            if (rightFaceType >= 0)
+                et.faceData.push_back({rightFaceType, /*onRight*/ true});
+            out.edgeTypes.push_back(std::move(et));
+            edgeTypeMap.emplace(std::move(key), idx);
+        } else {
+            idx = it->second;
+        }
+        out.edgeTypeOfEdge[ei] = idx;
+    }
+
+    // --- Step 5: vertex types (Phase A) ------------------------------------
+    // For each input vertex, walk the fan and collect (edgeType, isAtStart).
+    // isAtStart = true iff this half-edge is the canonical (halfA) direction
+    // of its edge — equivalent to "the half-edge starts at this vertex in the
+    // edge's stored orientation". Canonicalize by lexicographically smallest
+    // cyclic rotation, then dedupe.
+    out.vertexTypeOfVertex.resize(mesh.numVertices, -1);
+    out.halfEdgeSlotInVertex.resize(mesh.halfEdges.size(), -1);
+
+    struct CanonKey {
+        std::vector<int64_t> tokens;  // alternating edgeTypeIdx, isAtStart{0|1}
+        bool operator==(const CanonKey& o) const { return tokens == o.tokens; }
+    };
+    struct CanonKeyHash {
+        size_t operator()(const CanonKey& k) const {
+            size_t h = 0;
+            for (auto t : k.tokens)
+                h ^= std::hash<int64_t>{}(t) + 0x9E3779B9 + (h << 6) + (h >> 2);
+            return h;
+        }
+    };
+
+    std::unordered_map<CanonKey, int, CanonKeyHash> vertexTypeMap;
+    for (int v = 0; v < mesh.numVertices; ++v) {
+        if (mesh.vertexHalves[v].empty()) continue;  // unused vertex
+
+        std::vector<int> fan = walkVertexFan(mesh, v);
+        if (fan.empty()) {
+            if (error) {
+                char buf[160];
+                snprintf(buf, sizeof(buf),
+                         "vertex %d: cannot enumerate fan (open boundary or "
+                         "non-manifold) — Phase B canonicalizer needed", v);
+                *error = buf;
+            }
+            return false;
+        }
+
+        // Build raw token sequence (edgeType, isAtStart).
+        struct Slot { int edgeType; int isAtStart; };
+        std::vector<Slot> rawSlots;
+        rawSlots.reserve(fan.size());
+        for (int he : fan) {
+            int edgeIdx = mesh.halfEdges[he].edge;
+            int etIdx   = out.edgeTypeOfEdge[edgeIdx];
+            // isAtStart = "this half-edge is the canonical (halfA) direction"
+            bool isAtStart = (mesh.edges[edgeIdx].halfA == he);
+            rawSlots.push_back({etIdx, isAtStart ? 1 : 0});
+        }
+
+        // Find canonical rotation (lexicographically smallest).
+        int n = (int)rawSlots.size();
+        int best = 0;
+        for (int i = 1; i < n; ++i) {
+            for (int k = 0; k < n; ++k) {
+                const Slot& a = rawSlots[(best + k) % n];
+                const Slot& b = rawSlots[(i + k) % n];
+                if (a.edgeType != b.edgeType) {
+                    if (b.edgeType < a.edgeType) best = i;
+                    break;
+                }
+                if (a.isAtStart != b.isAtStart) {
+                    if (b.isAtStart < a.isAtStart) best = i;
+                    break;
+                }
+            }
+        }
+
+        CanonKey key;
+        key.tokens.reserve(n * 2);
+        for (int k = 0; k < n; ++k) {
+            const Slot& s = rawSlots[(best + k) % n];
+            key.tokens.push_back(s.edgeType);
+            key.tokens.push_back(s.isAtStart);
+        }
+
+        auto it = vertexTypeMap.find(key);
+        int vtIdx;
+        if (it == vertexTypeMap.end()) {
+            vtIdx = (int)out.vertexTypes.size();
+            ExtractedTypes::VertexType vt;
+            vt.halfEdgeTypes.reserve(n);
+            for (int k = 0; k < n; ++k) {
+                const Slot& s = rawSlots[(best + k) % n];
+                vt.halfEdgeTypes.push_back({s.edgeType, s.isAtStart != 0});
+            }
+            out.vertexTypes.push_back(std::move(vt));
+            vertexTypeMap.emplace(std::move(key), vtIdx);
+        } else {
+            vtIdx = it->second;
+        }
+        out.vertexTypeOfVertex[v] = vtIdx;
+
+        // Record per-original-halfedge slot index in the canonical vertex type.
+        // halfEdgeSlotInVertex[he] = position of `he` after rotation.
+        for (int k = 0; k < n; ++k) {
+            int srcIdx = (best + k) % n;
+            int he     = fan[srcIdx];
+            out.halfEdgeSlotInVertex[he] = k;
+        }
+    }
+
+    return true;
+}
+
+}  // namespace mesh_extraction

--- a/cpp_version/mesh_extraction/type_extractor.h
+++ b/cpp_version/mesh_extraction/type_extractor.h
@@ -1,0 +1,79 @@
+#pragma once
+// Steps 3-5 of MESH_TO_PRIMITIVES_PLAN.md: turn a half-edge mesh into the
+// primitive type vectors that a pmugg grammar needs — face types, edge types,
+// vertex types — plus per-element indices into those vectors.
+//
+// Outputs here are the canonical mesh→primitives schema in our own structs.
+// Step 7 (seed_grammar_writer) turns this into pmugg-loadable JSON.
+
+#include "mesh_extraction/half_edge_mesh.h"
+
+#include <string>
+#include <vector>
+
+namespace mesh_extraction {
+
+struct ExtractedTypes {
+    // ----- Face types (step 3). One per unique (material, volAbove, volBelow,
+    // normal_quantized). Identity preserves face-label semantics from §3.3
+    // and the 3D extension from §7 (volume labels) of Merrell 2023.
+    struct FaceType {
+        std::string material;
+        Vec3d       normal;
+        int         volAbove;
+        int         volBelow;
+    };
+    std::vector<FaceType> faceTypes;
+    std::vector<int>      faceTypeOfFace;       // [faceIdx] = faceType index
+
+    // ----- Edge types (step 4). One per unique (faceL, faceR, dir_quantized).
+    // `dir` is the unit vector from the canonical halfA's origin to its dest.
+    // `faceData[0]` is the face on the LEFT of `dir` (halfA's face) with
+    // onRight=false; `faceData[1]` is the RIGHT face (halfB's face) with
+    // onRight=true. Open-boundary edges omit the right-side entry.
+    struct FaceData {
+        int  faceType;   // index into faceTypes
+        bool onRight;
+    };
+    struct EdgeType {
+        std::vector<FaceData> faceData;
+        Vec3d                 dir;
+    };
+    std::vector<EdgeType> edgeTypes;
+    std::vector<int>      edgeTypeOfEdge;       // [edgeIdx] = edgeType index
+
+    // ----- Vertex types (step 5, Phase A). One per unique canonical σ — the
+    // cyclic CCW sequence of incident (edgeType, isAtStart) pairs around a
+    // vertex. We pick the lexicographically smallest rotation as the canonical
+    // form. This is the closed-manifold simplification of the paper's σ
+    // (§3.3 end). Phase B (general 3D σ-graph) is a later TODO.
+    struct HalfEdgeType {
+        int  edgeType;   // index into edgeTypes
+        bool isAtStart;  // true if this halfEdge originates at the vertex's "start"
+    };
+    struct VertexType {
+        std::vector<HalfEdgeType> halfEdgeTypes;
+    };
+    std::vector<VertexType> vertexTypes;
+    std::vector<int>        vertexTypeOfVertex;  // [vertIdx] = vertexType index
+
+    // ----- Per-original-halfedge index into vertexType.halfEdgeTypes. Used
+    // by step 6 (seed graph) to wire half-edge → vertex slot correctly.
+    std::vector<int> halfEdgeSlotInVertex;
+};
+
+struct TypeExtractionConfig {
+    double normalEps = 1e-4;   // quantization grid for face normals
+    double dirEps    = 1e-4;   // quantization grid for edge directions
+};
+
+// Extracts primitives from the half-edge mesh. Currently implements Phase A
+// (closed manifold with single-fan vertices). Returns false on inputs that
+// require Phase B.
+bool extractTypes(const HalfEdgeMesh&         mesh,
+                  const ObjMesh&              obj,           // for material lookup
+                  const TypeExtractionConfig& cfg,
+                  ExtractedTypes&             out,
+                  std::string*                error = nullptr);
+
+}  // namespace mesh_extraction

--- a/cpp_version/pmugg/pmugg.cpp
+++ b/cpp_version/pmugg/pmugg.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <vector>
 #include "../graph_grammar.h"
 #include "../mutator.h"
@@ -11,12 +12,62 @@
 #include "../util/util.h"
 #include "../json versioning/read_json_file.h"
 #include "../util/timer.h"
+#include "../mesh_extraction/obj_loader.h"
+#include "../mesh_extraction/half_edge_mesh.h"
+#include "../mesh_extraction/type_extractor.h"
+#include "../mesh_extraction/seed_grammar_writer.h"
 
 using namespace std;
 using Json = nlohmann::json;
 
+// Convert an OBJ mesh into a pmugg seed grammar JSON file.
+static int meshToGrammar(const char* objPath, const char* outPath) {
+	mesh_extraction::ObjMesh obj;
+	std::string err;
+	if (!mesh_extraction::loadObj(objPath, obj, &err)) {
+		cerr << "loadObj failed: " << err << endl;
+		return 1;
+	}
+	mesh_extraction::HalfEdgeMesh hem;
+	if (!mesh_extraction::buildHalfEdgeMesh(obj, hem, /*useGroupAsVolume*/ false, &err)) {
+		cerr << "buildHalfEdgeMesh failed: " << err << endl;
+		return 1;
+	}
+	mesh_extraction::ExtractedTypes types;
+	mesh_extraction::TypeExtractionConfig tcfg;
+	if (!mesh_extraction::extractTypes(hem, obj, tcfg, types, &err)) {
+		cerr << "extractTypes failed: " << err << endl;
+		return 1;
+	}
+	if (!mesh_extraction::writeSeedGrammar(hem, types, "seed", outPath, &err)) {
+		cerr << "writeSeedGrammar failed: " << err << endl;
+		return 1;
+	}
+	cout << "Wrote seed grammar to " << outPath
+	     << " (" << types.vertexTypes.size() << " vertex types, "
+	     << types.edgeTypes.size() << " edge types, "
+	     << types.faceTypes.size() << " face types)" << endl;
+
+	// Sanity-check that the JSON we just wrote loads via the normal pmugg
+	// grammar loader. The mutator isn't invoked here -- this is a parse check.
+	try {
+		Json parsed = readJsonFile(outPath, false);
+		auto* grammar = GraphGrammar::import(parsed);
+		cout << "  Round-trip: GraphGrammar::import succeeded." << endl;
+		delete grammar;
+	} catch (const std::exception& e) {
+		cerr << "  Round-trip: GraphGrammar::import threw: " << e.what() << endl;
+		return 2;
+	}
+	return 0;
+}
+
 // The main function for the command line version.
-int main() {
+int main(int argc, char** argv) {
+	if (argc >= 4 && std::string(argv[1]) == "--mesh-to-grammar") {
+		return meshToGrammar(argv[2], argv[3]);
+	}
+
 	vector<string> filePaths = {
 		"../../grammar data/3D Complex Shapes/castle.json",
 		"../../grammar data/2D Basic Shapes/square filled.json",

--- a/cpp_version/pmugg/pmugg.vcxproj
+++ b/cpp_version/pmugg/pmugg.vcxproj
@@ -81,7 +81,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>"$(ProjectDir)"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>"$(ProjectDir)";".."</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -98,7 +98,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>"$(ProjectDir)"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>"$(ProjectDir)";".."</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -114,7 +114,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>"$(ProjectDir)"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>"$(ProjectDir)";".."</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -132,7 +132,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>"$(ProjectDir)"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>"$(ProjectDir)";".."</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -175,6 +175,12 @@
     <ClCompile Include="..\json versioning\json_version_manager.cpp" />
     <ClCompile Include="..\json versioning\read_json_file.cpp" />
     <ClCompile Include="..\memory_counter.cpp" />
+    <ClCompile Include="..\mesh_extraction\half_edge_mesh.cpp" />
+    <ClCompile Include="..\mesh_extraction\obj_loader.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\mesh_extraction\seed_grammar_writer.cpp" />
+    <ClCompile Include="..\mesh_extraction\type_extractor.cpp" />
     <ClCompile Include="..\mutator.cpp" />
     <ClCompile Include="..\node_stats.cpp" />
     <ClCompile Include="..\optimizer.cpp" />
@@ -232,6 +238,10 @@
     <ClInclude Include="..\json versioning\json_version_manager.h" />
     <ClInclude Include="..\json versioning\read_json_file.h" />
     <ClInclude Include="..\memory_counter.h" />
+    <ClInclude Include="..\mesh_extraction\half_edge_mesh.h" />
+    <ClInclude Include="..\mesh_extraction\obj_loader.h" />
+    <ClInclude Include="..\mesh_extraction\seed_grammar_writer.h" />
+    <ClInclude Include="..\mesh_extraction\type_extractor.h" />
     <ClInclude Include="..\mutator.h" />
     <ClInclude Include="..\node_stats.h" />
     <ClInclude Include="..\optimizer.h" />
@@ -244,6 +254,7 @@
     <ClInclude Include="..\primitives\vertex_type.h" />
     <ClInclude Include="..\settings.h" />
     <ClInclude Include="..\third_party\json.h" />
+    <ClInclude Include="..\third_party\tinyobjloader\tiny_obj_loader.h" />
     <ClInclude Include="..\util\binary_stream.h" />
     <ClInclude Include="..\util\matrix.h" />
     <ClInclude Include="..\util\range.h" />

--- a/cpp_version/third_party/tinyobjloader/tiny_obj_loader.h
+++ b/cpp_version/third_party/tinyobjloader/tiny_obj_loader.h
@@ -1,0 +1,9267 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2012-Present, Syoyo Fujita and many contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+//
+// version 2.0.0 : Add new object oriented API. 1.x API is still provided.
+//                 * Add python binding.
+//                 * Support line primitive.
+//                 * Support points primitive.
+//                 * Support multiple search path for .mtl(v1 API).
+//                 * Support vertex skinning weight `vw`(as an tinyobj
+//                 extension). Note that this differs vertex weight([w]
+//                 component in `v` line)
+//                 * Support escaped whitespece in mtllib
+//                 * Add robust triangulation using Mapbox
+//                 earcut(TINYOBJLOADER_USE_MAPBOX_EARCUT).
+// version 1.4.0 : Modifed ParseTextureNameAndOption API
+// version 1.3.1 : Make ParseTextureNameAndOption API public
+// version 1.3.0 : Separate warning and error message(breaking API of LoadObj)
+// version 1.2.3 : Added color space extension('-colorspace') to tex opts.
+// version 1.2.2 : Parse multiple group names.
+// version 1.2.1 : Added initial support for line('l') primitive(PR #178)
+// version 1.2.0 : Hardened implementation(#175)
+// version 1.1.1 : Support smoothing groups(#162)
+// version 1.1.0 : Support parsing vertex color(#144)
+// version 1.0.8 : Fix parsing `g` tag just after `usemtl`(#138)
+// version 1.0.7 : Support multiple tex options(#126)
+// version 1.0.6 : Add TINYOBJLOADER_USE_DOUBLE option(#124)
+// version 1.0.5 : Ignore `Tr` when `d` exists in MTL(#43)
+// version 1.0.4 : Support multiple filenames for 'mtllib'(#112)
+// version 1.0.3 : Support parsing texture options(#85)
+// version 1.0.2 : Improve parsing speed by about a factor of 2 for large
+// files(#105)
+// version 1.0.1 : Fixes a shape is lost if obj ends with a 'usemtl'(#104)
+// version 1.0.0 : Change data structure. Change license from BSD to MIT.
+//
+
+//
+// Use this in *one* .cc
+//   #define TINYOBJLOADER_IMPLEMENTATION
+//   #include "tiny_obj_loader.h"
+//
+
+#ifndef TINY_OBJ_LOADER_H_
+#define TINY_OBJ_LOADER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace tinyobj {
+
+// C++11 is now the minimum required standard.
+#if __cplusplus < 201103L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201103L)
+#error "tinyobjloader requires C++11 or later. Compile with -std=c++11 or higher."
+#endif
+#define TINYOBJ_OVERRIDE override
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
+#pragma clang diagnostic ignored "-Wpadded"
+
+#endif
+
+// https://en.wikipedia.org/wiki/Wavefront_.obj_file says ...
+//
+//  -blendu on | off                       # set horizontal texture blending
+//  (default on)
+//  -blendv on | off                       # set vertical texture blending
+//  (default on)
+//  -boost real_value                      # boost mip-map sharpness
+//  -mm base_value gain_value              # modify texture map values (default
+//  0 1)
+//                                         #     base_value = brightness,
+//                                         gain_value = contrast
+//  -o u [v [w]]                           # Origin offset             (default
+//  0 0 0)
+//  -s u [v [w]]                           # Scale                     (default
+//  1 1 1)
+//  -t u [v [w]]                           # Turbulence                (default
+//  0 0 0)
+//  -texres resolution                     # texture resolution to create
+//  -clamp on | off                        # only render texels in the clamped
+//  0-1 range (default off)
+//                                         #   When unclamped, textures are
+//                                         repeated across a surface,
+//                                         #   when clamped, only texels which
+//                                         fall within the 0-1
+//                                         #   range are rendered.
+//  -bm mult_value                         # bump multiplier (for bump maps
+//  only)
+//
+//  -imfchan r | g | b | m | l | z         # specifies which channel of the file
+//  is used to
+//                                         # create a scalar or bump texture.
+//                                         r:red, g:green,
+//                                         # b:blue, m:matte, l:luminance,
+//                                         z:z-depth..
+//                                         # (the default for bump is 'l' and
+//                                         for decal is 'm')
+//  bump -imfchan r bumpmap.tga            # says to use the red channel of
+//  bumpmap.tga as the bumpmap
+//
+// For reflection maps...
+//
+//   -type sphere                           # specifies a sphere for a "refl"
+//   reflection map
+//   -type cube_top    | cube_bottom |      # when using a cube map, the texture
+//   file for each
+//         cube_front  | cube_back   |      # side of the cube is specified
+//         separately
+//         cube_left   | cube_right
+//
+// TinyObjLoader extension.
+//
+//   -colorspace SPACE                      # Color space of the texture. e.g.
+//   'sRGB` or 'linear'
+//
+
+#ifdef TINYOBJLOADER_USE_DOUBLE
+//#pragma message "using double"
+typedef double real_t;
+#else
+//#pragma message "using float"
+typedef float real_t;
+#endif
+
+typedef enum {
+  TEXTURE_TYPE_NONE,  // default
+  TEXTURE_TYPE_SPHERE,
+  TEXTURE_TYPE_CUBE_TOP,
+  TEXTURE_TYPE_CUBE_BOTTOM,
+  TEXTURE_TYPE_CUBE_FRONT,
+  TEXTURE_TYPE_CUBE_BACK,
+  TEXTURE_TYPE_CUBE_LEFT,
+  TEXTURE_TYPE_CUBE_RIGHT
+} texture_type_t;
+
+struct texture_option_t {
+  texture_type_t type;      // -type (default TEXTURE_TYPE_NONE)
+  real_t sharpness;         // -boost (default 1.0?)
+  real_t brightness;        // base_value in -mm option (default 0)
+  real_t contrast;          // gain_value in -mm option (default 1)
+  real_t origin_offset[3];  // -o u [v [w]] (default 0 0 0)
+  real_t scale[3];          // -s u [v [w]] (default 1 1 1)
+  real_t turbulence[3];     // -t u [v [w]] (default 0 0 0)
+  int texture_resolution;   // -texres resolution (No default value in the spec.
+                            // We'll use -1)
+  bool clamp;               // -clamp (default false)
+  char imfchan;  // -imfchan (the default for bump is 'l' and for decal is 'm')
+  bool blendu;   // -blendu (default on)
+  bool blendv;   // -blendv (default on)
+  real_t bump_multiplier;  // -bm (for bump maps only, default 1.0)
+
+  // extension
+  std::string colorspace;  // Explicitly specify color space of stored texel
+                           // value. Usually `sRGB` or `linear` (default empty).
+};
+
+struct material_t {
+  std::string name;
+
+  real_t ambient[3];
+  real_t diffuse[3];
+  real_t specular[3];
+  real_t transmittance[3];
+  real_t emission[3];
+  real_t shininess;
+  real_t ior;       // index of refraction
+  real_t dissolve;  // 1 == opaque; 0 == fully transparent
+  // illumination model (see http://www.fileformat.info/format/material/)
+  int illum;
+
+  int dummy;  // Suppress padding warning.
+
+  std::string ambient_texname;   // map_Ka. For ambient or ambient occlusion.
+  std::string diffuse_texname;   // map_Kd
+  std::string specular_texname;  // map_Ks
+  std::string specular_highlight_texname;  // map_Ns
+  std::string bump_texname;                // map_bump, map_Bump, bump
+  std::string displacement_texname;        // disp
+  std::string alpha_texname;               // map_d
+  std::string reflection_texname;          // refl
+
+  texture_option_t ambient_texopt;
+  texture_option_t diffuse_texopt;
+  texture_option_t specular_texopt;
+  texture_option_t specular_highlight_texopt;
+  texture_option_t bump_texopt;
+  texture_option_t displacement_texopt;
+  texture_option_t alpha_texopt;
+  texture_option_t reflection_texopt;
+
+  // PBR extension
+  // http://exocortex.com/blog/extending_wavefront_mtl_to_support_pbr
+  real_t roughness;            // [0, 1] default 0
+  real_t metallic;             // [0, 1] default 0
+  real_t sheen;                // [0, 1] default 0
+  real_t clearcoat_thickness;  // [0, 1] default 0
+  real_t clearcoat_roughness;  // [0, 1] default 0
+  real_t anisotropy;           // aniso. [0, 1] default 0
+  real_t anisotropy_rotation;  // anisor. [0, 1] default 0
+  real_t pad0;
+  std::string roughness_texname;  // map_Pr
+  std::string metallic_texname;   // map_Pm
+  std::string sheen_texname;      // map_Ps
+  std::string emissive_texname;   // map_Ke
+  std::string normal_texname;     // norm. For normal mapping.
+
+  texture_option_t roughness_texopt;
+  texture_option_t metallic_texopt;
+  texture_option_t sheen_texopt;
+  texture_option_t emissive_texopt;
+  texture_option_t normal_texopt;
+
+  int pad2;
+
+  std::map<std::string, std::string> unknown_parameter;
+
+#ifdef TINY_OBJ_LOADER_PYTHON_BINDING
+  // For pybind11
+  std::array<double, 3> GetDiffuse() {
+    std::array<double, 3> values;
+    values[0] = double(diffuse[0]);
+    values[1] = double(diffuse[1]);
+    values[2] = double(diffuse[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetSpecular() {
+    std::array<double, 3> values;
+    values[0] = double(specular[0]);
+    values[1] = double(specular[1]);
+    values[2] = double(specular[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetTransmittance() {
+    std::array<double, 3> values;
+    values[0] = double(transmittance[0]);
+    values[1] = double(transmittance[1]);
+    values[2] = double(transmittance[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetEmission() {
+    std::array<double, 3> values;
+    values[0] = double(emission[0]);
+    values[1] = double(emission[1]);
+    values[2] = double(emission[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetAmbient() {
+    std::array<double, 3> values;
+    values[0] = double(ambient[0]);
+    values[1] = double(ambient[1]);
+    values[2] = double(ambient[2]);
+
+    return values;
+  }
+
+  void SetDiffuse(std::array<double, 3> &a) {
+    diffuse[0] = real_t(a[0]);
+    diffuse[1] = real_t(a[1]);
+    diffuse[2] = real_t(a[2]);
+  }
+
+  void SetAmbient(std::array<double, 3> &a) {
+    ambient[0] = real_t(a[0]);
+    ambient[1] = real_t(a[1]);
+    ambient[2] = real_t(a[2]);
+  }
+
+  void SetSpecular(std::array<double, 3> &a) {
+    specular[0] = real_t(a[0]);
+    specular[1] = real_t(a[1]);
+    specular[2] = real_t(a[2]);
+  }
+
+  void SetTransmittance(std::array<double, 3> &a) {
+    transmittance[0] = real_t(a[0]);
+    transmittance[1] = real_t(a[1]);
+    transmittance[2] = real_t(a[2]);
+  }
+
+  std::string GetCustomParameter(const std::string &key) {
+    std::map<std::string, std::string>::const_iterator it =
+        unknown_parameter.find(key);
+
+    if (it != unknown_parameter.end()) {
+      return it->second;
+    }
+    return std::string();
+  }
+
+#endif
+};
+
+struct tag_t {
+  std::string name;
+
+  std::vector<int> intValues;
+  std::vector<real_t> floatValues;
+  std::vector<std::string> stringValues;
+};
+
+struct joint_and_weight_t {
+  int joint_id;
+  real_t weight;
+};
+
+struct skin_weight_t {
+  int vertex_id;  // Corresponding vertex index in `attrib_t::vertices`.
+                  // Compared to `index_t`, this index must be positive and
+                  // start with 0(does not allow relative indexing)
+  std::vector<joint_and_weight_t> weightValues;
+};
+
+// Index struct to support different indices for vtx/normal/texcoord.
+// -1 means not used.
+struct index_t {
+  int vertex_index;
+  int normal_index;
+  int texcoord_index;
+};
+
+struct mesh_t {
+  std::vector<index_t> indices;
+  std::vector<unsigned int>
+      num_face_vertices;          // The number of vertices per
+                                  // face. 3 = triangle, 4 = quad, ...
+  std::vector<int> material_ids;  // per-face material ID
+  std::vector<unsigned int> smoothing_group_ids;  // per-face smoothing group
+                                                  // ID(0 = off. positive value
+                                                  // = group id)
+  std::vector<tag_t> tags;                        // SubD tag
+};
+
+// struct path_t {
+//  std::vector<int> indices;  // pairs of indices for lines
+//};
+
+struct lines_t {
+  // Linear flattened indices.
+  std::vector<index_t> indices;        // indices for vertices(poly lines)
+  std::vector<int> num_line_vertices;  // The number of vertices per line.
+};
+
+struct points_t {
+  std::vector<index_t> indices;  // indices for points
+};
+
+struct shape_t {
+  std::string name;
+  mesh_t mesh;
+  lines_t lines;
+  points_t points;
+};
+
+// Vertex attributes
+struct attrib_t {
+  std::vector<real_t> vertices;  // 'v'(xyz)
+
+  // For backward compatibility, we store vertex weight in separate array.
+  std::vector<real_t> vertex_weights;  // 'v'(w)
+  std::vector<real_t> normals;         // 'vn'
+  std::vector<real_t> texcoords;       // 'vt'(uv)
+
+  // For backward compatibility, we store texture coordinate 'w' in separate
+  // array.
+  std::vector<real_t> texcoord_ws;  // 'vt'(w)
+  std::vector<real_t> colors;       // extension: vertex colors
+
+  //
+  // TinyObj extension.
+  //
+
+  // NOTE(syoyo): array index is based on the appearance order.
+  // To get a corresponding skin weight for a specific vertex id `vid`,
+  // Need to reconstruct a look up table: `skin_weight_t::vertex_id` == `vid`
+  // (e.g. using std::map, std::unordered_map)
+  std::vector<skin_weight_t> skin_weights;
+
+  attrib_t() {}
+
+  //
+  // For pybind11
+  //
+  const std::vector<real_t> &GetVertices() const { return vertices; }
+
+  const std::vector<real_t> &GetVertexWeights() const { return vertex_weights; }
+};
+
+struct callback_t {
+  // W is optional and set to 1 if there is no `w` item in `v` line
+  void (*vertex_cb)(void *user_data, real_t x, real_t y, real_t z, real_t w);
+  void (*vertex_color_cb)(void *user_data, real_t x, real_t y, real_t z,
+                          real_t r, real_t g, real_t b, bool has_color);
+  void (*normal_cb)(void *user_data, real_t x, real_t y, real_t z);
+
+  // y and z are optional and set to 0 if there is no `y` and/or `z` item(s) in
+  // `vt` line.
+  void (*texcoord_cb)(void *user_data, real_t x, real_t y, real_t z);
+
+  // called per 'f' line. num_indices is the number of face indices(e.g. 3 for
+  // triangle, 4 for quad)
+  // 0 will be passed for undefined index in index_t members.
+  void (*index_cb)(void *user_data, index_t *indices, int num_indices);
+  // `name` material name, `material_id` = the array index of material_t[]. -1
+  // if
+  // a material not found in .mtl
+  void (*usemtl_cb)(void *user_data, const char *name, int material_id);
+  // `materials` = parsed material data.
+  void (*mtllib_cb)(void *user_data, const material_t *materials,
+                    int num_materials);
+  // There may be multiple group names
+  void (*group_cb)(void *user_data, const char **names, int num_names);
+  void (*object_cb)(void *user_data, const char *name);
+
+  callback_t()
+      : vertex_cb(NULL),
+        vertex_color_cb(NULL),
+        normal_cb(NULL),
+        texcoord_cb(NULL),
+        index_cb(NULL),
+        usemtl_cb(NULL),
+        mtllib_cb(NULL),
+        group_cb(NULL),
+        object_cb(NULL) {}
+};
+
+class MaterialReader {
+ public:
+  MaterialReader() {}
+  virtual ~MaterialReader();
+
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *warn,
+                          std::string *err) = 0;
+};
+
+///
+/// Read .mtl from a file.
+///
+class MaterialFileReader : public MaterialReader {
+ public:
+  // Path could contain separator(';' in Windows, ':' in Posix)
+  explicit MaterialFileReader(const std::string &mtl_basedir)
+      : m_mtlBaseDir(mtl_basedir) {}
+  virtual ~MaterialFileReader() TINYOBJ_OVERRIDE {}
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *warn,
+                          std::string *err) TINYOBJ_OVERRIDE;
+
+ private:
+  std::string m_mtlBaseDir;
+};
+
+///
+/// Read .mtl from a stream.
+///
+class MaterialStreamReader : public MaterialReader {
+ public:
+  explicit MaterialStreamReader(std::istream &inStream)
+      : m_inStream(inStream) {}
+  virtual ~MaterialStreamReader() TINYOBJ_OVERRIDE {}
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *warn,
+                          std::string *err) TINYOBJ_OVERRIDE;
+
+ private:
+  std::istream &m_inStream;
+};
+
+// v2 API
+struct ObjReaderConfig {
+  bool triangulate;  // triangulate polygon?
+
+  // Currently not used.
+  // "simple" or empty: Create triangle fan
+  // "earcut": Use the algorithm based on Ear clipping
+  std::string triangulation_method;
+
+  /// Parse vertex color.
+  /// If vertex color is not present, its filled with default value.
+  /// false = no vertex color
+  /// This will increase memory of parsed .obj
+  bool vertex_color;
+
+  ///
+  /// Search path to .mtl file.
+  /// Default = "" = search from the same directory of .obj file.
+  /// Valid only when loading .obj from a file.
+  ///
+  std::string mtl_search_path;
+
+  ObjReaderConfig()
+      : triangulate(true), triangulation_method("simple"), vertex_color(true) {}
+};
+
+///
+/// Wavefront .obj reader class(v2 API)
+///
+class ObjReader {
+ public:
+  ObjReader() : valid_(false) {}
+
+  ///
+  /// Load .obj and .mtl from a file.
+  ///
+  /// @param[in] filename wavefront .obj filename
+  /// @param[in] config Reader configuration
+  ///
+  bool ParseFromFile(const std::string &filename,
+                     const ObjReaderConfig &config = ObjReaderConfig());
+
+  ///
+  /// Parse .obj from a text string.
+  /// Need to supply .mtl text string by `mtl_text`.
+  /// This function ignores `mtllib` line in .obj text.
+  ///
+  /// @param[in] obj_text wavefront .obj filename
+  /// @param[in] mtl_text wavefront .mtl filename
+  /// @param[in] config Reader configuration
+  ///
+  bool ParseFromString(const std::string &obj_text, const std::string &mtl_text,
+                       const ObjReaderConfig &config = ObjReaderConfig());
+
+  ///
+  /// .obj was loaded or parsed correctly.
+  ///
+  bool Valid() const { return valid_; }
+
+  const attrib_t &GetAttrib() const { return attrib_; }
+
+  const std::vector<shape_t> &GetShapes() const { return shapes_; }
+
+  const std::vector<material_t> &GetMaterials() const { return materials_; }
+
+  ///
+  /// Warning message(may be filled after `Load` or `Parse`)
+  ///
+  const std::string &Warning() const { return warning_; }
+
+  ///
+  /// Error message(filled when `Load` or `Parse` failed)
+  ///
+  const std::string &Error() const { return error_; }
+
+ private:
+  bool valid_;
+
+  attrib_t attrib_;
+  std::vector<shape_t> shapes_;
+  std::vector<material_t> materials_;
+
+  std::string warning_;
+  std::string error_;
+};
+
+/// ==>>========= Legacy v1 API =============================================
+
+/// Loads .obj from a file.
+/// 'attrib', 'shapes' and 'materials' will be filled with parsed shape data
+/// 'shapes' will be filled with parsed shape data
+/// Returns true when loading .obj become success.
+/// Returns warning message into `warn`, and error message into `err`
+/// 'mtl_basedir' is optional, and used for base directory for .mtl file.
+/// In default(`NULL'), .mtl file is searched from an application's working
+/// directory.
+/// 'triangulate' is optional, and used whether triangulate polygon face in .obj
+/// or not.
+/// Option 'default_vcols_fallback' specifies whether vertex colors should
+/// always be defined, even if no colors are given (fallback to white).
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, const char *filename,
+             const char *mtl_basedir = NULL, bool triangulate = true,
+             bool default_vcols_fallback = true);
+
+/// Loads .obj from a file with custom user callback.
+/// .mtl is loaded as usual and parsed material_t data will be passed to
+/// `callback.mtllib_cb`.
+/// Returns true when loading .obj/.mtl become success.
+/// Returns warning message into `warn`, and error message into `err`
+/// See `examples/callback_api/` for how to use this function.
+bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
+                         void *user_data = NULL,
+                         MaterialReader *readMatFn = NULL,
+                         std::string *warn = NULL, std::string *err = NULL);
+
+/// Loads object from a std::istream, uses `readMatFn` to retrieve
+/// std::istream for materials.
+/// Returns true when loading .obj become success.
+/// Returns warning and error message into `err`
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, std::istream *inStream,
+             MaterialReader *readMatFn = NULL, bool triangulate = true,
+             bool default_vcols_fallback = true);
+
+/// Loads materials into std::map
+void LoadMtl(std::map<std::string, int> *material_map,
+             std::vector<material_t> *materials, std::istream *inStream,
+             std::string *warning, std::string *err);
+
+///
+/// Parse texture name and texture option for custom texture parameter through
+/// material::unknown_parameter
+///
+/// @param[out] texname Parsed texture name
+/// @param[out] texopt Parsed texopt
+/// @param[in] linebuf Input string
+///
+bool ParseTextureNameAndOption(std::string *texname, texture_option_t *texopt,
+                               const char *linebuf);
+
+/// =<<========== Legacy v1 API =============================================
+
+}  // namespace tinyobj
+
+#endif  // TINY_OBJ_LOADER_H_
+
+#ifdef TINYOBJLOADER_IMPLEMENTATION
+#include <cassert>
+#include <cctype>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+#ifdef TINYOBJLOADER_USE_MMAP
+#if !defined(_WIN32)
+// POSIX headers for mmap
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+#endif  // TINYOBJLOADER_USE_MMAP
+#include <set>
+#include <sstream>
+#include <utility>
+
+#ifdef TINYOBJLOADER_USE_MAPBOX_EARCUT
+
+#ifdef TINYOBJLOADER_DONOT_INCLUDE_MAPBOX_EARCUT
+// Assume earcut.hpp is included outside of tiny_obj_loader.h
+#else
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+#endif
+
+#include <array>
+
+#include "mapbox/earcut.hpp"
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#endif
+
+#endif  // TINYOBJLOADER_USE_MAPBOX_EARCUT
+
+#ifdef _WIN32
+// Converts a UTF-8 encoded string to a UTF-16 wide string for use with
+// Windows file APIs that support Unicode paths (including paths longer than
+// MAX_PATH when combined with the extended-length path prefix).
+static std::wstring UTF8ToWchar(const std::string &str) {
+  if (str.empty()) return std::wstring();
+  int size_needed =
+      MultiByteToWideChar(CP_UTF8, 0, str.c_str(),
+                          static_cast<int>(str.size()), NULL, 0);
+  if (size_needed == 0) return std::wstring();
+  std::wstring wstr(static_cast<size_t>(size_needed), L'\0');
+  int result =
+      MultiByteToWideChar(CP_UTF8, 0, str.c_str(),
+                          static_cast<int>(str.size()), &wstr[0], size_needed);
+  if (result == 0) return std::wstring();
+  return wstr;
+}
+
+// Prepends the Windows extended-length path prefix ("\\?\") to an absolute
+// path when the path length meets or exceeds MAX_PATH (260 characters).
+// This allows Windows APIs to handle paths up to 32767 characters long.
+// UNC paths (starting with "\\") are converted to "\\?\UNC\" form.
+static std::wstring LongPathW(const std::wstring &wpath) {
+  const std::wstring kLongPathPrefix = L"\\\\?\\";
+  const std::wstring kUNCPrefix = L"\\\\";
+  const std::wstring kLongUNCPathPrefix = L"\\\\?\\UNC\\";
+
+  // Already has the extended-length prefix; return as-is.
+  if (wpath.size() >= kLongPathPrefix.size() &&
+      wpath.substr(0, kLongPathPrefix.size()) == kLongPathPrefix) {
+    return wpath;
+  }
+
+  // Only add the prefix when the path is long enough to require it.
+  if (wpath.size() < MAX_PATH) {
+    return wpath;
+  }
+
+  // Normalize forward slashes to backslashes: the extended-length "\\?\"
+  // prefix requires backslash separators only.
+  std::wstring normalized = wpath;
+  for (std::wstring::size_type i = 0; i < normalized.size(); ++i) {
+    if (normalized[i] == L'/') normalized[i] = L'\\';
+  }
+
+  // UNC path: "\\server\share\..." -> "\\?\UNC\server\share\..."
+  if (normalized.size() >= kUNCPrefix.size() &&
+      normalized.substr(0, kUNCPrefix.size()) == kUNCPrefix) {
+    return kLongUNCPathPrefix + normalized.substr(kUNCPrefix.size());
+  }
+
+  // Absolute path with drive letter: "C:\..." -> "\\?\C:\..."
+  if (normalized.size() >= 2 && normalized[1] == L':') {
+    return kLongPathPrefix + normalized;
+  }
+
+  return normalized;
+}
+#endif  // _WIN32
+
+// --------------------------------------------------------------------------
+// Embedded fast_float v8.0.2 for high-performance, bit-exact float parsing.
+// Disable by defining TINYOBJLOADER_DISABLE_FAST_FLOAT before including
+// this file with TINYOBJLOADER_IMPLEMENTATION.
+// --------------------------------------------------------------------------
+#ifndef TINYOBJLOADER_DISABLE_FAST_FLOAT
+
+// Standard headers needed by the embedded fast_float.
+#include <cfloat>
+#include <cstdint>
+
+namespace tinyobj_ff {
+
+// --- integral_constant, true_type, false_type ---
+template <typename T, T V>
+struct integral_constant {
+  static const T value = V;
+  typedef T value_type;
+  typedef integral_constant type;
+  operator value_type() const { return value; }
+};
+typedef integral_constant<bool, true>  true_type;
+typedef integral_constant<bool, false> false_type;
+
+// --- is_same ---
+template <typename T, typename U> struct is_same       : false_type {};
+template <typename T>             struct is_same<T, T> : true_type  {};
+
+// --- enable_if ---
+template <bool B, typename T = void> struct enable_if {};
+template <typename T>                struct enable_if<true, T> { typedef T type; };
+
+// --- conditional ---
+template <bool B, typename T, typename F> struct conditional              { typedef T type; };
+template <typename T, typename F>         struct conditional<false, T, F> { typedef F type; };
+
+// --- is_integral ---
+template <typename T> struct is_integral : false_type {};
+template <> struct is_integral<bool>               : true_type {};
+template <> struct is_integral<char>               : true_type {};
+template <> struct is_integral<signed char>        : true_type {};
+template <> struct is_integral<unsigned char>      : true_type {};
+template <> struct is_integral<short>              : true_type {};
+template <> struct is_integral<unsigned short>     : true_type {};
+template <> struct is_integral<int>                : true_type {};
+template <> struct is_integral<unsigned int>       : true_type {};
+template <> struct is_integral<long>               : true_type {};
+template <> struct is_integral<unsigned long>      : true_type {};
+template <> struct is_integral<long long>          : true_type {};
+template <> struct is_integral<unsigned long long> : true_type {};
+template <> struct is_integral<wchar_t>            : true_type {};
+template <> struct is_integral<char16_t>           : true_type {};
+template <> struct is_integral<char32_t>           : true_type {};
+
+// --- is_signed ---
+template <typename T> struct is_signed : integral_constant<bool, T(-1) < T(0)> {};
+
+// --- underlying_type (uses compiler builtin) ---
+template <typename T> struct underlying_type {
+  typedef __underlying_type(T) type;
+};
+
+// --- ff_errc (replaces std::errc, our own enum - no system_error needed) ---
+enum class ff_errc { ok = 0, invalid_argument = 22, result_out_of_range = 34 };
+
+// --- min_val (replaces std::min, avoids Windows min/max macro conflicts) ---
+template <typename T>
+inline T min_val(T a, T b) { return (b < a) ? b : a; }
+
+// --- copy_n ---
+template <typename InputIt, typename Size, typename OutputIt>
+inline OutputIt copy_n(InputIt first, Size count, OutputIt result) {
+  for (Size i = 0; i < count; ++i) *result++ = *first++;
+  return result;
+}
+
+// --- copy_backward ---
+template <typename BidirIt1, typename BidirIt2>
+inline BidirIt2 copy_backward(BidirIt1 first, BidirIt1 last, BidirIt2 d_last) {
+  while (first != last) *(--d_last) = *(--last);
+  return d_last;
+}
+
+// --- fill ---
+template <typename ForwardIt, typename T>
+inline void fill(ForwardIt first, ForwardIt last, const T &value) {
+  for (; first != last; ++first) *first = value;
+}
+
+// --- distance ---
+template <typename It>
+inline typename conditional<true, long long, It>::type
+distance(It first, It last) {
+  return last - first;
+}
+
+}  // namespace tinyobj_ff
+
+// --- Begin embedded fast_float v8.0.2 (MIT / Apache-2.0 / BSL-1.0) ---
+// https://github.com/fastfloat/fast_float
+// fast_float by Daniel Lemire
+// fast_float by João Paulo Magalhaes
+//
+//
+// with contributions from Eugene Golushkov
+// with contributions from Maksim Kita
+// with contributions from Marcin Wojdyr
+// with contributions from Neal Richardson
+// with contributions from Tim Paine
+// with contributions from Fabio Pellacini
+// with contributions from Lénárd Szolnoki
+// with contributions from Jan Pharago
+// with contributions from Maya Warrier
+// with contributions from Taha Khokhar
+// with contributions from Anders Dalvander
+//
+//
+// Licensed under the Apache License, Version 2.0, or the
+// MIT License or the Boost License. This file may not be copied,
+// modified, or distributed except according to those terms.
+//
+// MIT License Notice
+//
+//    MIT License
+//
+//    Copyright (c) 2021 The fast_float authors
+//
+//    Permission is hereby granted, free of charge, to any
+//    person obtaining a copy of this software and associated
+//    documentation files (the "Software"), to deal in the
+//    Software without restriction, including without
+//    limitation the rights to use, copy, modify, merge,
+//    publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software
+//    is furnished to do so, subject to the following
+//    conditions:
+//
+//    The above copyright notice and this permission notice
+//    shall be included in all copies or substantial portions
+//    of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+//    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+//    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//    PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+//    SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//    IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//    DEALINGS IN THE SOFTWARE.
+//
+// Apache License (Version 2.0) Notice
+//
+//    Copyright 2021 The fast_float authors
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//
+// BOOST License Notice
+//
+//    Boost Software License - Version 1.0 - August 17th, 2003
+//
+//    Permission is hereby granted, free of charge, to any person or organization
+//    obtaining a copy of the software and accompanying documentation covered by
+//    this license (the "Software") to use, reproduce, display, distribute,
+//    execute, and transmit the Software, and to prepare derivative works of the
+//    Software, and to permit third-parties to whom the Software is furnished to
+//    do so, all subject to the following:
+//
+//    The copyright notices in the Software and this entire statement, including
+//    the above license grant, this restriction and the following disclaimer,
+//    must be included in all copies of the Software, in whole or in part, and
+//    all derivative works of the Software, unless such copies or derivative
+//    works are solely in the form of machine-executable object code generated by
+//    a source language processor.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+//    SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+//    FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+//    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//    DEALINGS IN THE SOFTWARE.
+//
+
+#ifndef FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
+#define FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
+
+#ifdef __has_include
+#if __has_include(<version>)
+#include <version>
+#endif
+#endif
+
+// Testing for https://wg21.link/N3652, adopted in C++14
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#define FASTFLOAT_CONSTEXPR14 constexpr
+#else
+#define FASTFLOAT_CONSTEXPR14
+#endif
+
+#if defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L
+#define FASTFLOAT_HAS_BIT_CAST 1
+#else
+#define FASTFLOAT_HAS_BIT_CAST 0
+#endif
+
+#if defined(__cpp_lib_is_constant_evaluated) &&                                \
+    __cpp_lib_is_constant_evaluated >= 201811L
+#define FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 1
+#else
+#define FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 0
+#endif
+
+#if defined(__cpp_if_constexpr) && __cpp_if_constexpr >= 201606L
+#define FASTFLOAT_IF_CONSTEXPR17(x) if constexpr (x)
+#else
+#define FASTFLOAT_IF_CONSTEXPR17(x) if (x)
+#endif
+
+// Testing for relevant C++20 constexpr library features
+#if FASTFLOAT_HAS_IS_CONSTANT_EVALUATED && FASTFLOAT_HAS_BIT_CAST &&           \
+    defined(__cpp_lib_constexpr_algorithms) &&                                 \
+    __cpp_lib_constexpr_algorithms >= 201806L /*For std::copy and std::fill*/
+#define FASTFLOAT_CONSTEXPR20 constexpr
+#define FASTFLOAT_IS_CONSTEXPR 1
+#else
+#define FASTFLOAT_CONSTEXPR20
+#define FASTFLOAT_IS_CONSTEXPR 0
+#endif
+
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE 0
+#else
+#define FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE 1
+#endif
+
+#endif // FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
+
+#ifndef FASTFLOAT_FLOAT_COMMON_H
+#define FASTFLOAT_FLOAT_COMMON_H
+
+#include <cassert>
+#include <cstring>
+#include <limits>
+#ifdef __has_include
+#if __has_include(<stdfloat>) && (__cplusplus > 202002L || (defined(_MSVC_LANG) && (_MSVC_LANG > 202002L)))
+#include <stdfloat>
+#endif
+#endif
+
+#define FASTFLOAT_VERSION_MAJOR 8
+#define FASTFLOAT_VERSION_MINOR 0
+#define FASTFLOAT_VERSION_PATCH 2
+
+#define FASTFLOAT_STRINGIZE_IMPL(x) #x
+#define FASTFLOAT_STRINGIZE(x) FASTFLOAT_STRINGIZE_IMPL(x)
+
+#define FASTFLOAT_VERSION_STR                                                  \
+  FASTFLOAT_STRINGIZE(FASTFLOAT_VERSION_MAJOR)                                 \
+  "." FASTFLOAT_STRINGIZE(FASTFLOAT_VERSION_MINOR) "." FASTFLOAT_STRINGIZE(    \
+      FASTFLOAT_VERSION_PATCH)
+
+#define FASTFLOAT_VERSION                                                      \
+  (FASTFLOAT_VERSION_MAJOR * 10000 + FASTFLOAT_VERSION_MINOR * 100 +           \
+   FASTFLOAT_VERSION_PATCH)
+
+namespace fast_float {
+
+enum class chars_format : uint64_t;
+
+namespace detail {
+constexpr chars_format basic_json_fmt = chars_format(1 << 5);
+constexpr chars_format basic_fortran_fmt = chars_format(1 << 6);
+} // namespace detail
+
+enum class chars_format : uint64_t {
+  scientific = 1 << 0,
+  fixed = 1 << 2,
+  hex = 1 << 3,
+  no_infnan = 1 << 4,
+  // RFC 8259: https://datatracker.ietf.org/doc/html/rfc8259#section-6
+  json = uint64_t(detail::basic_json_fmt) | fixed | scientific | no_infnan,
+  // Extension of RFC 8259 where, e.g., "inf" and "nan" are allowed.
+  json_or_infnan = uint64_t(detail::basic_json_fmt) | fixed | scientific,
+  fortran = uint64_t(detail::basic_fortran_fmt) | fixed | scientific,
+  general = fixed | scientific,
+  allow_leading_plus = 1 << 7,
+  skip_white_space = 1 << 8,
+};
+
+template <typename UC> struct from_chars_result_t {
+  UC const *ptr;
+  tinyobj_ff::ff_errc ec;
+};
+
+using from_chars_result = from_chars_result_t<char>;
+
+template <typename UC> struct parse_options_t {
+  constexpr explicit parse_options_t(chars_format fmt = chars_format::general,
+                                     UC dot = UC('.'), int b = 10)
+      : format(fmt), decimal_point(dot), base(b) {}
+
+  /** Which number formats are accepted */
+  chars_format format;
+  /** The character used as decimal point */
+  UC decimal_point;
+  /** The base used for integers */
+  int base;
+};
+
+using parse_options = parse_options_t<char>;
+
+} // namespace fast_float
+
+#if FASTFLOAT_HAS_BIT_CAST
+#include <bit>
+#endif
+
+#if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64) ||            \
+     defined(__amd64) || defined(__aarch64__) || defined(_M_ARM64) ||          \
+     defined(__MINGW64__) || defined(__s390x__) ||                             \
+     (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) ||      \
+      defined(__PPC64LE__)) ||                                                 \
+     defined(__loongarch64))
+#define FASTFLOAT_64BIT 1
+#elif (defined(__i386) || defined(__i386__) || defined(_M_IX86) ||             \
+       defined(__arm__) || defined(_M_ARM) || defined(__ppc__) ||              \
+       defined(__MINGW32__) || defined(__EMSCRIPTEN__))
+#define FASTFLOAT_32BIT 1
+#else
+  // Need to check incrementally, since SIZE_MAX is a size_t, avoid overflow.
+// We can never tell the register width, but the SIZE_MAX is a good
+// approximation. UINTPTR_MAX and INTPTR_MAX are optional, so avoid them for max
+// portability.
+#if SIZE_MAX == 0xffff
+#error Unknown platform (16-bit, unsupported)
+#elif SIZE_MAX == 0xffffffff
+#define FASTFLOAT_32BIT 1
+#elif SIZE_MAX == 0xffffffffffffffff
+#define FASTFLOAT_64BIT 1
+#else
+#error Unknown platform (not 32-bit, not 64-bit?)
+#endif
+#endif
+
+#if ((defined(_WIN32) || defined(_WIN64)) && !defined(__clang__)) ||           \
+    (defined(_M_ARM64) && !defined(__MINGW32__))
+#include <intrin.h>
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define FASTFLOAT_VISUAL_STUDIO 1
+#endif
+
+#if defined __BYTE_ORDER__ && defined __ORDER_BIG_ENDIAN__
+#define FASTFLOAT_IS_BIG_ENDIAN (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#elif defined _WIN32
+#define FASTFLOAT_IS_BIG_ENDIAN 0
+#else
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <machine/endian.h>
+#elif defined(sun) || defined(__sun)
+#include <sys/byteorder.h>
+#elif defined(__MVS__)
+#include <sys/endian.h>
+#else
+#ifdef __has_include
+#if __has_include(<endian.h>)
+#include <endian.h>
+#endif //__has_include(<endian.h>)
+#endif //__has_include
+#endif
+#
+#ifndef __BYTE_ORDER__
+// safe choice
+#define FASTFLOAT_IS_BIG_ENDIAN 0
+#endif
+#
+#ifndef __ORDER_LITTLE_ENDIAN__
+// safe choice
+#define FASTFLOAT_IS_BIG_ENDIAN 0
+#endif
+#
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define FASTFLOAT_IS_BIG_ENDIAN 0
+#else
+#define FASTFLOAT_IS_BIG_ENDIAN 1
+#endif
+#endif
+
+#if defined(__SSE2__) || (defined(FASTFLOAT_VISUAL_STUDIO) &&                  \
+                          (defined(_M_AMD64) || defined(_M_X64) ||             \
+                           (defined(_M_IX86_FP) && _M_IX86_FP == 2)))
+#define FASTFLOAT_SSE2 1
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define FASTFLOAT_NEON 1
+#endif
+
+#if defined(FASTFLOAT_SSE2) || defined(FASTFLOAT_NEON)
+#define FASTFLOAT_HAS_SIMD 1
+#endif
+
+#if defined(__GNUC__)
+// disable -Wcast-align=strict (GCC only)
+#define FASTFLOAT_SIMD_DISABLE_WARNINGS                                        \
+  _Pragma("GCC diagnostic push")                                               \
+      _Pragma("GCC diagnostic ignored \"-Wcast-align\"")
+#else
+#define FASTFLOAT_SIMD_DISABLE_WARNINGS
+#endif
+
+#if defined(__GNUC__)
+#define FASTFLOAT_SIMD_RESTORE_WARNINGS _Pragma("GCC diagnostic pop")
+#else
+#define FASTFLOAT_SIMD_RESTORE_WARNINGS
+#endif
+
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#define fastfloat_really_inline __forceinline
+#else
+#define fastfloat_really_inline inline __attribute__((always_inline))
+#endif
+
+#ifndef FASTFLOAT_ASSERT
+#define FASTFLOAT_ASSERT(x)                                                    \
+  { ((void)(x)); }
+#endif
+
+#ifndef FASTFLOAT_DEBUG_ASSERT
+#define FASTFLOAT_DEBUG_ASSERT(x)                                              \
+  { ((void)(x)); }
+#endif
+
+// rust style `try!()` macro, or `?` operator
+#define FASTFLOAT_TRY(x)                                                       \
+  {                                                                            \
+    if (!(x))                                                                  \
+      return false;                                                            \
+  }
+
+#define FASTFLOAT_ENABLE_IF(...)                                               \
+  typename tinyobj_ff::enable_if<(__VA_ARGS__), int>::type
+
+namespace fast_float {
+
+fastfloat_really_inline constexpr bool cpp20_and_in_constexpr() {
+#if FASTFLOAT_HAS_IS_CONSTANT_EVALUATED
+  return std::is_constant_evaluated();
+#else
+  return false;
+#endif
+}
+
+template <typename T>
+struct is_supported_float_type
+    : tinyobj_ff::integral_constant<
+          bool, tinyobj_ff::is_same<T, double>::value || tinyobj_ff::is_same<T, float>::value
+#ifdef __STDCPP_FLOAT64_T__
+                    || tinyobj_ff::is_same<T, std::float64_t>::value
+#endif
+#ifdef __STDCPP_FLOAT32_T__
+                    || tinyobj_ff::is_same<T, std::float32_t>::value
+#endif
+#ifdef __STDCPP_FLOAT16_T__
+                    || tinyobj_ff::is_same<T, std::float16_t>::value
+#endif
+#ifdef __STDCPP_BFLOAT16_T__
+                    || tinyobj_ff::is_same<T, std::bfloat16_t>::value
+#endif
+          > {
+};
+
+template <typename T>
+using equiv_uint_t = typename tinyobj_ff::conditional<
+    sizeof(T) == 1, uint8_t,
+    typename tinyobj_ff::conditional<
+        sizeof(T) == 2, uint16_t,
+        typename tinyobj_ff::conditional<sizeof(T) == 4, uint32_t,
+                                  uint64_t>::type>::type>::type;
+
+template <typename T> struct is_supported_integer_type : tinyobj_ff::is_integral<T> {};
+
+template <typename UC>
+struct is_supported_char_type
+    : tinyobj_ff::integral_constant<bool, tinyobj_ff::is_same<UC, char>::value ||
+                                       tinyobj_ff::is_same<UC, wchar_t>::value ||
+                                       tinyobj_ff::is_same<UC, char16_t>::value ||
+                                       tinyobj_ff::is_same<UC, char32_t>::value
+#ifdef __cpp_char8_t
+                                       || tinyobj_ff::is_same<UC, char8_t>::value
+#endif
+                             > {
+};
+
+// Compares two ASCII strings in a case insensitive manner.
+template <typename UC>
+inline FASTFLOAT_CONSTEXPR14 bool
+fastfloat_strncasecmp(UC const *actual_mixedcase, UC const *expected_lowercase,
+                      size_t length) {
+  for (size_t i = 0; i < length; ++i) {
+    UC const actual = actual_mixedcase[i];
+    if ((actual < 256 ? actual | 32 : actual) != expected_lowercase[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+#ifndef FLT_EVAL_METHOD
+#error "FLT_EVAL_METHOD should be defined, please include cfloat."
+#endif
+
+// a pointer and a length to a contiguous block of memory
+template <typename T> struct span {
+  T const *ptr;
+  size_t length;
+
+  constexpr span(T const *_ptr, size_t _length) : ptr(_ptr), length(_length) {}
+
+  constexpr span() : ptr(nullptr), length(0) {}
+
+  constexpr size_t len() const noexcept { return length; }
+
+  FASTFLOAT_CONSTEXPR14 const T &operator[](size_t index) const noexcept {
+    FASTFLOAT_DEBUG_ASSERT(index < length);
+    return ptr[index];
+  }
+};
+
+struct value128 {
+  uint64_t low;
+  uint64_t high;
+
+  constexpr value128(uint64_t _low, uint64_t _high) : low(_low), high(_high) {}
+
+  constexpr value128() : low(0), high(0) {}
+};
+
+/* Helper C++14 constexpr generic implementation of leading_zeroes */
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 int
+leading_zeroes_generic(uint64_t input_num, int last_bit = 0) {
+  if (input_num & uint64_t(0xffffffff00000000)) {
+    input_num >>= 32;
+    last_bit |= 32;
+  }
+  if (input_num & uint64_t(0xffff0000)) {
+    input_num >>= 16;
+    last_bit |= 16;
+  }
+  if (input_num & uint64_t(0xff00)) {
+    input_num >>= 8;
+    last_bit |= 8;
+  }
+  if (input_num & uint64_t(0xf0)) {
+    input_num >>= 4;
+    last_bit |= 4;
+  }
+  if (input_num & uint64_t(0xc)) {
+    input_num >>= 2;
+    last_bit |= 2;
+  }
+  if (input_num & uint64_t(0x2)) { /* input_num >>=  1; */
+    last_bit |= 1;
+  }
+  return 63 - last_bit;
+}
+
+/* result might be undefined when input_num is zero */
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 int
+leading_zeroes(uint64_t input_num) {
+  assert(input_num > 0);
+  if (cpp20_and_in_constexpr()) {
+    return leading_zeroes_generic(input_num);
+  }
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#if defined(_M_X64) || defined(_M_ARM64)
+  unsigned long leading_zero = 0;
+  // Search the mask data from most significant bit (MSB)
+  // to least significant bit (LSB) for a set bit (1).
+  _BitScanReverse64(&leading_zero, input_num);
+  return (int)(63 - leading_zero);
+#else
+  return leading_zeroes_generic(input_num);
+#endif
+#else
+  return __builtin_clzll(input_num);
+#endif
+}
+
+// slow emulation routine for 32-bit
+fastfloat_really_inline constexpr uint64_t emulu(uint32_t x, uint32_t y) {
+  return x * (uint64_t)y;
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 uint64_t
+umul128_generic(uint64_t ab, uint64_t cd, uint64_t *hi) {
+  uint64_t ad = emulu((uint32_t)(ab >> 32), (uint32_t)cd);
+  uint64_t bd = emulu((uint32_t)ab, (uint32_t)cd);
+  uint64_t adbc = ad + emulu((uint32_t)ab, (uint32_t)(cd >> 32));
+  uint64_t adbc_carry = (uint64_t)(adbc < ad);
+  uint64_t lo = bd + (adbc << 32);
+  *hi = emulu((uint32_t)(ab >> 32), (uint32_t)(cd >> 32)) + (adbc >> 32) +
+        (adbc_carry << 32) + (uint64_t)(lo < bd);
+  return lo;
+}
+
+#ifdef FASTFLOAT_32BIT
+
+// slow emulation routine for 32-bit
+#if !defined(__MINGW64__)
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 uint64_t _umul128(uint64_t ab,
+                                                                uint64_t cd,
+                                                                uint64_t *hi) {
+  return umul128_generic(ab, cd, hi);
+}
+#endif // !__MINGW64__
+
+#endif // FASTFLOAT_32BIT
+
+// compute 64-bit a*b
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 value128
+full_multiplication(uint64_t a, uint64_t b) {
+  if (cpp20_and_in_constexpr()) {
+    value128 answer;
+    answer.low = umul128_generic(a, b, &answer.high);
+    return answer;
+  }
+  value128 answer;
+#if defined(_M_ARM64) && !defined(__MINGW32__)
+  // ARM64 has native support for 64-bit multiplications, no need to emulate
+  // But MinGW on ARM64 doesn't have native support for 64-bit multiplications
+  answer.high = __umulh(a, b);
+  answer.low = a * b;
+#elif defined(FASTFLOAT_32BIT) ||                                              \
+    (defined(_WIN64) && !defined(__clang__) && !defined(_M_ARM64))
+  answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
+#elif defined(FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
+  __uint128_t r = ((__uint128_t)a) * b;
+  answer.low = uint64_t(r);
+  answer.high = uint64_t(r >> 64);
+#else
+  answer.low = umul128_generic(a, b, &answer.high);
+#endif
+  return answer;
+}
+
+struct adjusted_mantissa {
+  uint64_t mantissa{0};
+  int32_t power2{0}; // a negative value indicates an invalid result
+  adjusted_mantissa() = default;
+
+  constexpr bool operator==(adjusted_mantissa const &o) const {
+    return mantissa == o.mantissa && power2 == o.power2;
+  }
+
+  constexpr bool operator!=(adjusted_mantissa const &o) const {
+    return mantissa != o.mantissa || power2 != o.power2;
+  }
+};
+
+// Bias so we can get the real exponent with an invalid adjusted_mantissa.
+constexpr static int32_t invalid_am_bias = -0x8000;
+
+// used for binary_format_lookup_tables<T>::max_mantissa
+constexpr uint64_t constant_55555 = 5 * 5 * 5 * 5 * 5;
+
+template <typename T, typename U = void> struct binary_format_lookup_tables;
+
+template <typename T> struct binary_format : binary_format_lookup_tables<T> {
+  using equiv_uint = equiv_uint_t<T>;
+
+  static constexpr int mantissa_explicit_bits();
+  static constexpr int minimum_exponent();
+  static constexpr int infinite_power();
+  static constexpr int sign_index();
+  static constexpr int
+  min_exponent_fast_path(); // used when fegetround() == FE_TONEAREST
+  static constexpr int max_exponent_fast_path();
+  static constexpr int max_exponent_round_to_even();
+  static constexpr int min_exponent_round_to_even();
+  static constexpr uint64_t max_mantissa_fast_path(int64_t power);
+  static constexpr uint64_t
+  max_mantissa_fast_path(); // used when fegetround() == FE_TONEAREST
+  static constexpr int largest_power_of_ten();
+  static constexpr int smallest_power_of_ten();
+  static constexpr T exact_power_of_ten(int64_t power);
+  static constexpr size_t max_digits();
+  static constexpr equiv_uint exponent_mask();
+  static constexpr equiv_uint mantissa_mask();
+  static constexpr equiv_uint hidden_bit_mask();
+};
+
+template <typename U> struct binary_format_lookup_tables<double, U> {
+  static constexpr double powers_of_ten[] = {
+      1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
+      1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22};
+
+  // Largest integer value v so that (5**index * v) <= 1<<53.
+  // 0x20000000000000 == 1 << 53
+  static constexpr uint64_t max_mantissa[] = {
+      0x20000000000000,
+      0x20000000000000 / 5,
+      0x20000000000000 / (5 * 5),
+      0x20000000000000 / (5 * 5 * 5),
+      0x20000000000000 / (5 * 5 * 5 * 5),
+      0x20000000000000 / (constant_55555),
+      0x20000000000000 / (constant_55555 * 5),
+      0x20000000000000 / (constant_55555 * 5 * 5),
+      0x20000000000000 / (constant_55555 * 5 * 5 * 5),
+      0x20000000000000 / (constant_55555 * 5 * 5 * 5 * 5),
+      0x20000000000000 / (constant_55555 * constant_55555),
+      0x20000000000000 / (constant_55555 * constant_55555 * 5),
+      0x20000000000000 / (constant_55555 * constant_55555 * 5 * 5),
+      0x20000000000000 / (constant_55555 * constant_55555 * 5 * 5 * 5),
+      0x20000000000000 / (constant_55555 * constant_55555 * constant_55555),
+      0x20000000000000 / (constant_55555 * constant_55555 * constant_55555 * 5),
+      0x20000000000000 /
+          (constant_55555 * constant_55555 * constant_55555 * 5 * 5),
+      0x20000000000000 /
+          (constant_55555 * constant_55555 * constant_55555 * 5 * 5 * 5),
+      0x20000000000000 /
+          (constant_55555 * constant_55555 * constant_55555 * 5 * 5 * 5 * 5),
+      0x20000000000000 /
+          (constant_55555 * constant_55555 * constant_55555 * constant_55555),
+      0x20000000000000 / (constant_55555 * constant_55555 * constant_55555 *
+                          constant_55555 * 5),
+      0x20000000000000 / (constant_55555 * constant_55555 * constant_55555 *
+                          constant_55555 * 5 * 5),
+      0x20000000000000 / (constant_55555 * constant_55555 * constant_55555 *
+                          constant_55555 * 5 * 5 * 5),
+      0x20000000000000 / (constant_55555 * constant_55555 * constant_55555 *
+                          constant_55555 * 5 * 5 * 5 * 5)};
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <typename U>
+constexpr double binary_format_lookup_tables<double, U>::powers_of_ten[];
+
+template <typename U>
+constexpr uint64_t binary_format_lookup_tables<double, U>::max_mantissa[];
+
+#endif
+
+template <typename U> struct binary_format_lookup_tables<float, U> {
+  static constexpr float powers_of_ten[] = {1e0f, 1e1f, 1e2f, 1e3f, 1e4f, 1e5f,
+                                            1e6f, 1e7f, 1e8f, 1e9f, 1e10f};
+
+  // Largest integer value v so that (5**index * v) <= 1<<24.
+  // 0x1000000 == 1<<24
+  static constexpr uint64_t max_mantissa[] = {
+      0x1000000,
+      0x1000000 / 5,
+      0x1000000 / (5 * 5),
+      0x1000000 / (5 * 5 * 5),
+      0x1000000 / (5 * 5 * 5 * 5),
+      0x1000000 / (constant_55555),
+      0x1000000 / (constant_55555 * 5),
+      0x1000000 / (constant_55555 * 5 * 5),
+      0x1000000 / (constant_55555 * 5 * 5 * 5),
+      0x1000000 / (constant_55555 * 5 * 5 * 5 * 5),
+      0x1000000 / (constant_55555 * constant_55555),
+      0x1000000 / (constant_55555 * constant_55555 * 5)};
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <typename U>
+constexpr float binary_format_lookup_tables<float, U>::powers_of_ten[];
+
+template <typename U>
+constexpr uint64_t binary_format_lookup_tables<float, U>::max_mantissa[];
+
+#endif
+
+template <>
+inline constexpr int binary_format<double>::min_exponent_fast_path() {
+#if (FLT_EVAL_METHOD != 1) && (FLT_EVAL_METHOD != 0)
+  return 0;
+#else
+  return -22;
+#endif
+}
+
+template <>
+inline constexpr int binary_format<float>::min_exponent_fast_path() {
+#if (FLT_EVAL_METHOD != 1) && (FLT_EVAL_METHOD != 0)
+  return 0;
+#else
+  return -10;
+#endif
+}
+
+template <>
+inline constexpr int binary_format<double>::mantissa_explicit_bits() {
+  return 52;
+}
+
+template <>
+inline constexpr int binary_format<float>::mantissa_explicit_bits() {
+  return 23;
+}
+
+template <>
+inline constexpr int binary_format<double>::max_exponent_round_to_even() {
+  return 23;
+}
+
+template <>
+inline constexpr int binary_format<float>::max_exponent_round_to_even() {
+  return 10;
+}
+
+template <>
+inline constexpr int binary_format<double>::min_exponent_round_to_even() {
+  return -4;
+}
+
+template <>
+inline constexpr int binary_format<float>::min_exponent_round_to_even() {
+  return -17;
+}
+
+template <> inline constexpr int binary_format<double>::minimum_exponent() {
+  return -1023;
+}
+
+template <> inline constexpr int binary_format<float>::minimum_exponent() {
+  return -127;
+}
+
+template <> inline constexpr int binary_format<double>::infinite_power() {
+  return 0x7FF;
+}
+
+template <> inline constexpr int binary_format<float>::infinite_power() {
+  return 0xFF;
+}
+
+template <> inline constexpr int binary_format<double>::sign_index() {
+  return 63;
+}
+
+template <> inline constexpr int binary_format<float>::sign_index() {
+  return 31;
+}
+
+template <>
+inline constexpr int binary_format<double>::max_exponent_fast_path() {
+  return 22;
+}
+
+template <>
+inline constexpr int binary_format<float>::max_exponent_fast_path() {
+  return 10;
+}
+
+template <>
+inline constexpr uint64_t binary_format<double>::max_mantissa_fast_path() {
+  return uint64_t(2) << mantissa_explicit_bits();
+}
+
+template <>
+inline constexpr uint64_t binary_format<float>::max_mantissa_fast_path() {
+  return uint64_t(2) << mantissa_explicit_bits();
+}
+
+// credit: Jakub Jelínek
+#ifdef __STDCPP_FLOAT16_T__
+template <typename U> struct binary_format_lookup_tables<std::float16_t, U> {
+  static constexpr std::float16_t powers_of_ten[] = {1e0f16, 1e1f16, 1e2f16,
+                                                     1e3f16, 1e4f16};
+
+  // Largest integer value v so that (5**index * v) <= 1<<11.
+  // 0x800 == 1<<11
+  static constexpr uint64_t max_mantissa[] = {0x800,
+                                              0x800 / 5,
+                                              0x800 / (5 * 5),
+                                              0x800 / (5 * 5 * 5),
+                                              0x800 / (5 * 5 * 5 * 5),
+                                              0x800 / (constant_55555)};
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <typename U>
+constexpr std::float16_t
+    binary_format_lookup_tables<std::float16_t, U>::powers_of_ten[];
+
+template <typename U>
+constexpr uint64_t
+    binary_format_lookup_tables<std::float16_t, U>::max_mantissa[];
+
+#endif
+
+template <>
+inline constexpr std::float16_t
+binary_format<std::float16_t>::exact_power_of_ten(int64_t power) {
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)powers_of_ten[0], powers_of_ten[power];
+}
+
+template <>
+inline constexpr binary_format<std::float16_t>::equiv_uint
+binary_format<std::float16_t>::exponent_mask() {
+  return 0x7C00;
+}
+
+template <>
+inline constexpr binary_format<std::float16_t>::equiv_uint
+binary_format<std::float16_t>::mantissa_mask() {
+  return 0x03FF;
+}
+
+template <>
+inline constexpr binary_format<std::float16_t>::equiv_uint
+binary_format<std::float16_t>::hidden_bit_mask() {
+  return 0x0400;
+}
+
+template <>
+inline constexpr int binary_format<std::float16_t>::max_exponent_fast_path() {
+  return 4;
+}
+
+template <>
+inline constexpr int binary_format<std::float16_t>::mantissa_explicit_bits() {
+  return 10;
+}
+
+template <>
+inline constexpr uint64_t
+binary_format<std::float16_t>::max_mantissa_fast_path() {
+  return uint64_t(2) << mantissa_explicit_bits();
+}
+
+template <>
+inline constexpr uint64_t
+binary_format<std::float16_t>::max_mantissa_fast_path(int64_t power) {
+  // caller is responsible to ensure that
+  // power >= 0 && power <= 4
+  //
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)max_mantissa[0], max_mantissa[power];
+}
+
+template <>
+inline constexpr int binary_format<std::float16_t>::min_exponent_fast_path() {
+  return 0;
+}
+
+template <>
+inline constexpr int
+binary_format<std::float16_t>::max_exponent_round_to_even() {
+  return 5;
+}
+
+template <>
+inline constexpr int
+binary_format<std::float16_t>::min_exponent_round_to_even() {
+  return -22;
+}
+
+template <>
+inline constexpr int binary_format<std::float16_t>::minimum_exponent() {
+  return -15;
+}
+
+template <>
+inline constexpr int binary_format<std::float16_t>::infinite_power() {
+  return 0x1F;
+}
+
+template <> inline constexpr int binary_format<std::float16_t>::sign_index() {
+  return 15;
+}
+
+template <>
+inline constexpr int binary_format<std::float16_t>::largest_power_of_ten() {
+  return 4;
+}
+
+template <>
+inline constexpr int binary_format<std::float16_t>::smallest_power_of_ten() {
+  return -27;
+}
+
+template <>
+inline constexpr size_t binary_format<std::float16_t>::max_digits() {
+  return 22;
+}
+#endif // __STDCPP_FLOAT16_T__
+
+// credit: Jakub Jelínek
+#ifdef __STDCPP_BFLOAT16_T__
+template <typename U> struct binary_format_lookup_tables<std::bfloat16_t, U> {
+  static constexpr std::bfloat16_t powers_of_ten[] = {1e0bf16, 1e1bf16, 1e2bf16,
+                                                      1e3bf16};
+
+  // Largest integer value v so that (5**index * v) <= 1<<8.
+  // 0x100 == 1<<8
+  static constexpr uint64_t max_mantissa[] = {0x100, 0x100 / 5, 0x100 / (5 * 5),
+                                              0x100 / (5 * 5 * 5),
+                                              0x100 / (5 * 5 * 5 * 5)};
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <typename U>
+constexpr std::bfloat16_t
+    binary_format_lookup_tables<std::bfloat16_t, U>::powers_of_ten[];
+
+template <typename U>
+constexpr uint64_t
+    binary_format_lookup_tables<std::bfloat16_t, U>::max_mantissa[];
+
+#endif
+
+template <>
+inline constexpr std::bfloat16_t
+binary_format<std::bfloat16_t>::exact_power_of_ten(int64_t power) {
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)powers_of_ten[0], powers_of_ten[power];
+}
+
+template <>
+inline constexpr int binary_format<std::bfloat16_t>::max_exponent_fast_path() {
+  return 3;
+}
+
+template <>
+inline constexpr binary_format<std::bfloat16_t>::equiv_uint
+binary_format<std::bfloat16_t>::exponent_mask() {
+  return 0x7F80;
+}
+
+template <>
+inline constexpr binary_format<std::bfloat16_t>::equiv_uint
+binary_format<std::bfloat16_t>::mantissa_mask() {
+  return 0x007F;
+}
+
+template <>
+inline constexpr binary_format<std::bfloat16_t>::equiv_uint
+binary_format<std::bfloat16_t>::hidden_bit_mask() {
+  return 0x0080;
+}
+
+template <>
+inline constexpr int binary_format<std::bfloat16_t>::mantissa_explicit_bits() {
+  return 7;
+}
+
+template <>
+inline constexpr uint64_t
+binary_format<std::bfloat16_t>::max_mantissa_fast_path() {
+  return uint64_t(2) << mantissa_explicit_bits();
+}
+
+template <>
+inline constexpr uint64_t
+binary_format<std::bfloat16_t>::max_mantissa_fast_path(int64_t power) {
+  // caller is responsible to ensure that
+  // power >= 0 && power <= 3
+  //
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)max_mantissa[0], max_mantissa[power];
+}
+
+template <>
+inline constexpr int binary_format<std::bfloat16_t>::min_exponent_fast_path() {
+  return 0;
+}
+
+template <>
+inline constexpr int
+binary_format<std::bfloat16_t>::max_exponent_round_to_even() {
+  return 3;
+}
+
+template <>
+inline constexpr int
+binary_format<std::bfloat16_t>::min_exponent_round_to_even() {
+  return -24;
+}
+
+template <>
+inline constexpr int binary_format<std::bfloat16_t>::minimum_exponent() {
+  return -127;
+}
+
+template <>
+inline constexpr int binary_format<std::bfloat16_t>::infinite_power() {
+  return 0xFF;
+}
+
+template <> inline constexpr int binary_format<std::bfloat16_t>::sign_index() {
+  return 15;
+}
+
+template <>
+inline constexpr int binary_format<std::bfloat16_t>::largest_power_of_ten() {
+  return 38;
+}
+
+template <>
+inline constexpr int binary_format<std::bfloat16_t>::smallest_power_of_ten() {
+  return -60;
+}
+
+template <>
+inline constexpr size_t binary_format<std::bfloat16_t>::max_digits() {
+  return 98;
+}
+#endif // __STDCPP_BFLOAT16_T__
+
+template <>
+inline constexpr uint64_t
+binary_format<double>::max_mantissa_fast_path(int64_t power) {
+  // caller is responsible to ensure that
+  // power >= 0 && power <= 22
+  //
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)max_mantissa[0], max_mantissa[power];
+}
+
+template <>
+inline constexpr uint64_t
+binary_format<float>::max_mantissa_fast_path(int64_t power) {
+  // caller is responsible to ensure that
+  // power >= 0 && power <= 10
+  //
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)max_mantissa[0], max_mantissa[power];
+}
+
+template <>
+inline constexpr double
+binary_format<double>::exact_power_of_ten(int64_t power) {
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)powers_of_ten[0], powers_of_ten[power];
+}
+
+template <>
+inline constexpr float binary_format<float>::exact_power_of_ten(int64_t power) {
+  // Work around clang bug https://godbolt.org/z/zedh7rrhc
+  return (void)powers_of_ten[0], powers_of_ten[power];
+}
+
+template <> inline constexpr int binary_format<double>::largest_power_of_ten() {
+  return 308;
+}
+
+template <> inline constexpr int binary_format<float>::largest_power_of_ten() {
+  return 38;
+}
+
+template <>
+inline constexpr int binary_format<double>::smallest_power_of_ten() {
+  return -342;
+}
+
+template <> inline constexpr int binary_format<float>::smallest_power_of_ten() {
+  return -64;
+}
+
+template <> inline constexpr size_t binary_format<double>::max_digits() {
+  return 769;
+}
+
+template <> inline constexpr size_t binary_format<float>::max_digits() {
+  return 114;
+}
+
+template <>
+inline constexpr binary_format<float>::equiv_uint
+binary_format<float>::exponent_mask() {
+  return 0x7F800000;
+}
+
+template <>
+inline constexpr binary_format<double>::equiv_uint
+binary_format<double>::exponent_mask() {
+  return 0x7FF0000000000000;
+}
+
+template <>
+inline constexpr binary_format<float>::equiv_uint
+binary_format<float>::mantissa_mask() {
+  return 0x007FFFFF;
+}
+
+template <>
+inline constexpr binary_format<double>::equiv_uint
+binary_format<double>::mantissa_mask() {
+  return 0x000FFFFFFFFFFFFF;
+}
+
+template <>
+inline constexpr binary_format<float>::equiv_uint
+binary_format<float>::hidden_bit_mask() {
+  return 0x00800000;
+}
+
+template <>
+inline constexpr binary_format<double>::equiv_uint
+binary_format<double>::hidden_bit_mask() {
+  return 0x0010000000000000;
+}
+
+template <typename T>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
+to_float(bool negative, adjusted_mantissa am, T &value) {
+  using equiv_uint = equiv_uint_t<T>;
+  equiv_uint word = equiv_uint(am.mantissa);
+  word = equiv_uint(word | equiv_uint(am.power2)
+                               << binary_format<T>::mantissa_explicit_bits());
+  word =
+      equiv_uint(word | equiv_uint(negative) << binary_format<T>::sign_index());
+#if FASTFLOAT_HAS_BIT_CAST
+  value = std::bit_cast<T>(word);
+#else
+  ::memcpy(&value, &word, sizeof(T));
+#endif
+}
+
+template <typename = void> struct space_lut {
+  static constexpr bool value[] = {
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <typename T> constexpr bool space_lut<T>::value[];
+
+#endif
+
+template <typename UC> constexpr bool is_space(UC c) {
+  return c < 256 && space_lut<>::value[uint8_t(c)];
+}
+
+template <typename UC> static constexpr uint64_t int_cmp_zeros() {
+  static_assert((sizeof(UC) == 1) || (sizeof(UC) == 2) || (sizeof(UC) == 4),
+                "Unsupported character size");
+  return (sizeof(UC) == 1) ? 0x3030303030303030
+         : (sizeof(UC) == 2)
+             ? (uint64_t(UC('0')) << 48 | uint64_t(UC('0')) << 32 |
+                uint64_t(UC('0')) << 16 | UC('0'))
+             : (uint64_t(UC('0')) << 32 | UC('0'));
+}
+
+template <typename UC> static constexpr int int_cmp_len() {
+  return sizeof(uint64_t) / sizeof(UC);
+}
+
+template <typename UC> constexpr UC const *str_const_nan();
+
+template <> constexpr char const *str_const_nan<char>() { return "nan"; }
+
+template <> constexpr wchar_t const *str_const_nan<wchar_t>() { return L"nan"; }
+
+template <> constexpr char16_t const *str_const_nan<char16_t>() {
+  return u"nan";
+}
+
+template <> constexpr char32_t const *str_const_nan<char32_t>() {
+  return U"nan";
+}
+
+#ifdef __cpp_char8_t
+template <> constexpr char8_t const *str_const_nan<char8_t>() {
+  return u8"nan";
+}
+#endif
+
+template <typename UC> constexpr UC const *str_const_inf();
+
+template <> constexpr char const *str_const_inf<char>() { return "infinity"; }
+
+template <> constexpr wchar_t const *str_const_inf<wchar_t>() {
+  return L"infinity";
+}
+
+template <> constexpr char16_t const *str_const_inf<char16_t>() {
+  return u"infinity";
+}
+
+template <> constexpr char32_t const *str_const_inf<char32_t>() {
+  return U"infinity";
+}
+
+#ifdef __cpp_char8_t
+template <> constexpr char8_t const *str_const_inf<char8_t>() {
+  return u8"infinity";
+}
+#endif
+
+template <typename = void> struct int_luts {
+  static constexpr uint8_t chdigit[] = {
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   255, 255,
+      255, 255, 255, 255, 255, 10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
+      20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,
+      35,  255, 255, 255, 255, 255, 255, 10,  11,  12,  13,  14,  15,  16,  17,
+      18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,
+      33,  34,  35,  255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      255};
+
+  static constexpr size_t maxdigits_u64[] = {
+      64, 41, 32, 28, 25, 23, 22, 21, 20, 19, 18, 18, 17, 17, 16, 16, 16, 16,
+      15, 15, 15, 15, 14, 14, 14, 14, 14, 14, 14, 13, 13, 13, 13, 13, 13};
+
+  static constexpr uint64_t min_safe_u64[] = {
+      9223372036854775808ull,  12157665459056928801ull, 4611686018427387904,
+      7450580596923828125,     4738381338321616896,     3909821048582988049,
+      9223372036854775808ull,  12157665459056928801ull, 10000000000000000000ull,
+      5559917313492231481,     2218611106740436992,     8650415919381337933,
+      2177953337809371136,     6568408355712890625,     1152921504606846976,
+      2862423051509815793,     6746640616477458432,     15181127029874798299ull,
+      1638400000000000000,     3243919932521508681,     6221821273427820544,
+      11592836324538749809ull, 876488338465357824,      1490116119384765625,
+      2481152873203736576,     4052555153018976267,     6502111422497947648,
+      10260628712958602189ull, 15943230000000000000ull, 787662783788549761,
+      1152921504606846976,     1667889514952984961,     2386420683693101056,
+      3379220508056640625,     4738381338321616896};
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <typename T> constexpr uint8_t int_luts<T>::chdigit[];
+
+template <typename T> constexpr size_t int_luts<T>::maxdigits_u64[];
+
+template <typename T> constexpr uint64_t int_luts<T>::min_safe_u64[];
+
+#endif
+
+template <typename UC>
+fastfloat_really_inline constexpr uint8_t ch_to_digit(UC c) {
+  return int_luts<>::chdigit[static_cast<unsigned char>(c)];
+}
+
+fastfloat_really_inline constexpr size_t max_digits_u64(int base) {
+  return int_luts<>::maxdigits_u64[base - 2];
+}
+
+// If a u64 is exactly max_digits_u64() in length, this is
+// the value below which it has definitely overflowed.
+fastfloat_really_inline constexpr uint64_t min_safe_u64(int base) {
+  return int_luts<>::min_safe_u64[base - 2];
+}
+
+static_assert(tinyobj_ff::is_same<equiv_uint_t<double>, uint64_t>::value,
+              "equiv_uint should be uint64_t for double");
+static_assert(std::numeric_limits<double>::is_iec559,
+              "double must fulfill the requirements of IEC 559 (IEEE 754)");
+
+static_assert(tinyobj_ff::is_same<equiv_uint_t<float>, uint32_t>::value,
+              "equiv_uint should be uint32_t for float");
+static_assert(std::numeric_limits<float>::is_iec559,
+              "float must fulfill the requirements of IEC 559 (IEEE 754)");
+
+#ifdef __STDCPP_FLOAT64_T__
+static_assert(tinyobj_ff::is_same<equiv_uint_t<std::float64_t>, uint64_t>::value,
+              "equiv_uint should be uint64_t for std::float64_t");
+static_assert(
+    std::numeric_limits<std::float64_t>::is_iec559,
+    "std::float64_t must fulfill the requirements of IEC 559 (IEEE 754)");
+#endif // __STDCPP_FLOAT64_T__
+
+#ifdef __STDCPP_FLOAT32_T__
+static_assert(tinyobj_ff::is_same<equiv_uint_t<std::float32_t>, uint32_t>::value,
+              "equiv_uint should be uint32_t for std::float32_t");
+static_assert(
+    std::numeric_limits<std::float32_t>::is_iec559,
+    "std::float32_t must fulfill the requirements of IEC 559 (IEEE 754)");
+#endif // __STDCPP_FLOAT32_T__
+
+#ifdef __STDCPP_FLOAT16_T__
+static_assert(
+    tinyobj_ff::is_same<binary_format<std::float16_t>::equiv_uint, uint16_t>::value,
+    "equiv_uint should be uint16_t for std::float16_t");
+static_assert(
+    std::numeric_limits<std::float16_t>::is_iec559,
+    "std::float16_t must fulfill the requirements of IEC 559 (IEEE 754)");
+#endif // __STDCPP_FLOAT16_T__
+
+#ifdef __STDCPP_BFLOAT16_T__
+static_assert(
+    tinyobj_ff::is_same<binary_format<std::bfloat16_t>::equiv_uint, uint16_t>::value,
+    "equiv_uint should be uint16_t for std::bfloat16_t");
+static_assert(
+    std::numeric_limits<std::bfloat16_t>::is_iec559,
+    "std::bfloat16_t must fulfill the requirements of IEC 559 (IEEE 754)");
+#endif // __STDCPP_BFLOAT16_T__
+
+constexpr chars_format operator~(chars_format rhs) noexcept {
+  using int_type = tinyobj_ff::underlying_type<chars_format>::type;
+  return static_cast<chars_format>(~static_cast<int_type>(rhs));
+}
+
+constexpr chars_format operator&(chars_format lhs, chars_format rhs) noexcept {
+  using int_type = tinyobj_ff::underlying_type<chars_format>::type;
+  return static_cast<chars_format>(static_cast<int_type>(lhs) &
+                                   static_cast<int_type>(rhs));
+}
+
+constexpr chars_format operator|(chars_format lhs, chars_format rhs) noexcept {
+  using int_type = tinyobj_ff::underlying_type<chars_format>::type;
+  return static_cast<chars_format>(static_cast<int_type>(lhs) |
+                                   static_cast<int_type>(rhs));
+}
+
+constexpr chars_format operator^(chars_format lhs, chars_format rhs) noexcept {
+  using int_type = tinyobj_ff::underlying_type<chars_format>::type;
+  return static_cast<chars_format>(static_cast<int_type>(lhs) ^
+                                   static_cast<int_type>(rhs));
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 chars_format &
+operator&=(chars_format &lhs, chars_format rhs) noexcept {
+  return lhs = (lhs & rhs);
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 chars_format &
+operator|=(chars_format &lhs, chars_format rhs) noexcept {
+  return lhs = (lhs | rhs);
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 chars_format &
+operator^=(chars_format &lhs, chars_format rhs) noexcept {
+  return lhs = (lhs ^ rhs);
+}
+
+namespace detail {
+// adjust for deprecated feature macros
+constexpr chars_format adjust_for_feature_macros(chars_format fmt) {
+  return fmt
+#ifdef FASTFLOAT_ALLOWS_LEADING_PLUS
+         | chars_format::allow_leading_plus
+#endif
+#ifdef FASTFLOAT_SKIP_WHITE_SPACE
+         | chars_format::skip_white_space
+#endif
+      ;
+}
+} // namespace detail
+
+} // namespace fast_float
+
+#endif
+
+
+#ifndef FASTFLOAT_FAST_FLOAT_H
+#define FASTFLOAT_FAST_FLOAT_H
+
+
+namespace fast_float {
+/**
+ * This function parses the character sequence [first,last) for a number. It
+ * parses floating-point numbers expecting a locale-indepent format equivalent
+ * to what is used by std::strtod in the default ("C") locale. The resulting
+ * floating-point value is the closest floating-point values (using either float
+ * or double), using the "round to even" convention for values that would
+ * otherwise fall right in-between two values. That is, we provide exact parsing
+ * according to the IEEE standard.
+ *
+ * Given a successful parse, the pointer (`ptr`) in the returned value is set to
+ * point right after the parsed number, and the `value` referenced is set to the
+ * parsed value. In case of error, the returned `ec` contains a representative
+ * error, otherwise the default (`tinyobj_ff::ff_errc()`) value is stored.
+ *
+ * The implementation does not throw and does not allocate memory (e.g., with
+ * `new` or `malloc`).
+ *
+ * Like the C++17 standard, the `fast_float::from_chars` functions take an
+ * optional last argument of the type `fast_float::chars_format`. It is a bitset
+ * value: we check whether `fmt & fast_float::chars_format::fixed` and `fmt &
+ * fast_float::chars_format::scientific` are set to determine whether we allow
+ * the fixed point and scientific notation respectively. The default is
+ * `fast_float::chars_format::general` which allows both `fixed` and
+ * `scientific`.
+ */
+template <typename T, typename UC = char,
+          typename = FASTFLOAT_ENABLE_IF(is_supported_float_type<T>::value)>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars(UC const *first, UC const *last, T &value,
+           chars_format fmt = chars_format::general) noexcept;
+
+/**
+ * Like from_chars, but accepts an `options` argument to govern number parsing.
+ * Both for floating-point types and integer types.
+ */
+template <typename T, typename UC = char>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars_advanced(UC const *first, UC const *last, T &value,
+                    parse_options_t<UC> options) noexcept;
+
+/**
+ * from_chars for integer types.
+ */
+template <typename T, typename UC = char,
+          typename = FASTFLOAT_ENABLE_IF(is_supported_integer_type<T>::value)>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars(UC const *first, UC const *last, T &value, int base = 10) noexcept;
+
+} // namespace fast_float
+
+#endif // FASTFLOAT_FAST_FLOAT_H
+
+#ifndef FASTFLOAT_ASCII_NUMBER_H
+#define FASTFLOAT_ASCII_NUMBER_H
+
+#include <cctype>
+#include <cstring>
+#include <limits>
+
+
+#ifdef FASTFLOAT_SSE2
+#include <emmintrin.h>
+#endif
+
+#ifdef FASTFLOAT_NEON
+#include <arm_neon.h>
+#endif
+
+namespace fast_float {
+
+template <typename UC> fastfloat_really_inline constexpr bool has_simd_opt() {
+#ifdef FASTFLOAT_HAS_SIMD
+  return tinyobj_ff::is_same<UC, char16_t>::value;
+#else
+  return false;
+#endif
+}
+
+// Next function can be micro-optimized, but compilers are entirely
+// able to optimize it well.
+template <typename UC>
+fastfloat_really_inline constexpr bool is_integer(UC c) noexcept {
+  return !(c > UC('9') || c < UC('0'));
+}
+
+fastfloat_really_inline constexpr uint64_t byteswap(uint64_t val) {
+  return (val & 0xFF00000000000000) >> 56 | (val & 0x00FF000000000000) >> 40 |
+         (val & 0x0000FF0000000000) >> 24 | (val & 0x000000FF00000000) >> 8 |
+         (val & 0x00000000FF000000) << 8 | (val & 0x0000000000FF0000) << 24 |
+         (val & 0x000000000000FF00) << 40 | (val & 0x00000000000000FF) << 56;
+}
+
+// Read 8 UC into a u64. Truncates UC if not char.
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 uint64_t
+read8_to_u64(UC const *chars) {
+  if (cpp20_and_in_constexpr() || !tinyobj_ff::is_same<UC, char>::value) {
+    uint64_t val = 0;
+    for (int i = 0; i < 8; ++i) {
+      val |= uint64_t(uint8_t(*chars)) << (i * 8);
+      ++chars;
+    }
+    return val;
+  }
+  uint64_t val;
+  ::memcpy(&val, chars, sizeof(uint64_t));
+#if FASTFLOAT_IS_BIG_ENDIAN == 1
+  // Need to read as-if the number was in little-endian order.
+  val = byteswap(val);
+#endif
+  return val;
+}
+
+#ifdef FASTFLOAT_SSE2
+
+fastfloat_really_inline uint64_t simd_read8_to_u64(__m128i const data) {
+  FASTFLOAT_SIMD_DISABLE_WARNINGS
+  __m128i const packed = _mm_packus_epi16(data, data);
+#ifdef FASTFLOAT_64BIT
+  return uint64_t(_mm_cvtsi128_si64(packed));
+#else
+  uint64_t value;
+  // Visual Studio + older versions of GCC don't support _mm_storeu_si64
+  _mm_storel_epi64(reinterpret_cast<__m128i *>(&value), packed);
+  return value;
+#endif
+  FASTFLOAT_SIMD_RESTORE_WARNINGS
+}
+
+fastfloat_really_inline uint64_t simd_read8_to_u64(char16_t const *chars) {
+  FASTFLOAT_SIMD_DISABLE_WARNINGS
+  return simd_read8_to_u64(
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(chars)));
+  FASTFLOAT_SIMD_RESTORE_WARNINGS
+}
+
+#elif defined(FASTFLOAT_NEON)
+
+fastfloat_really_inline uint64_t simd_read8_to_u64(uint16x8_t const data) {
+  FASTFLOAT_SIMD_DISABLE_WARNINGS
+  uint8x8_t utf8_packed = vmovn_u16(data);
+  return vget_lane_u64(vreinterpret_u64_u8(utf8_packed), 0);
+  FASTFLOAT_SIMD_RESTORE_WARNINGS
+}
+
+fastfloat_really_inline uint64_t simd_read8_to_u64(char16_t const *chars) {
+  FASTFLOAT_SIMD_DISABLE_WARNINGS
+  return simd_read8_to_u64(
+      vld1q_u16(reinterpret_cast<uint16_t const *>(chars)));
+  FASTFLOAT_SIMD_RESTORE_WARNINGS
+}
+
+#endif // FASTFLOAT_SSE2
+
+// MSVC SFINAE is broken pre-VS2017
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+template <typename UC>
+#else
+template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>()) = 0>
+#endif
+// dummy for compile
+uint64_t simd_read8_to_u64(UC const *) {
+  return 0;
+}
+
+// credit  @aqrit
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 uint32_t
+parse_eight_digits_unrolled(uint64_t val) {
+  uint64_t const mask = 0x000000FF000000FF;
+  uint64_t const mul1 = 0x000F424000000064; // 100 + (1000000ULL << 32)
+  uint64_t const mul2 = 0x0000271000000001; // 1 + (10000ULL << 32)
+  val -= 0x3030303030303030;
+  val = (val * 10) + (val >> 8); // val = (val * 2561) >> 8;
+  val = (((val & mask) * mul1) + (((val >> 16) & mask) * mul2)) >> 32;
+  return uint32_t(val);
+}
+
+// Call this if chars are definitely 8 digits.
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 uint32_t
+parse_eight_digits_unrolled(UC const *chars) noexcept {
+  if (cpp20_and_in_constexpr() || !has_simd_opt<UC>()) {
+    return parse_eight_digits_unrolled(read8_to_u64(chars)); // truncation okay
+  }
+  return parse_eight_digits_unrolled(simd_read8_to_u64(chars));
+}
+
+// credit @aqrit
+fastfloat_really_inline constexpr bool
+is_made_of_eight_digits_fast(uint64_t val) noexcept {
+  return !((((val + 0x4646464646464646) | (val - 0x3030303030303030)) &
+            0x8080808080808080));
+}
+
+#ifdef FASTFLOAT_HAS_SIMD
+
+// Call this if chars might not be 8 digits.
+// Using this style (instead of is_made_of_eight_digits_fast() then
+// parse_eight_digits_unrolled()) ensures we don't load SIMD registers twice.
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 bool
+simd_parse_if_eight_digits_unrolled(char16_t const *chars,
+                                    uint64_t &i) noexcept {
+  if (cpp20_and_in_constexpr()) {
+    return false;
+  }
+#ifdef FASTFLOAT_SSE2
+  FASTFLOAT_SIMD_DISABLE_WARNINGS
+  __m128i const data =
+      _mm_loadu_si128(reinterpret_cast<__m128i const *>(chars));
+
+  // (x - '0') <= 9
+  // http://0x80.pl/articles/simd-parsing-int-sequences.html
+  __m128i const t0 = _mm_add_epi16(data, _mm_set1_epi16(32720));
+  __m128i const t1 = _mm_cmpgt_epi16(t0, _mm_set1_epi16(-32759));
+
+  if (_mm_movemask_epi8(t1) == 0) {
+    i = i * 100000000 + parse_eight_digits_unrolled(simd_read8_to_u64(data));
+    return true;
+  } else
+    return false;
+  FASTFLOAT_SIMD_RESTORE_WARNINGS
+#elif defined(FASTFLOAT_NEON)
+  FASTFLOAT_SIMD_DISABLE_WARNINGS
+  uint16x8_t const data = vld1q_u16(reinterpret_cast<uint16_t const *>(chars));
+
+  // (x - '0') <= 9
+  // http://0x80.pl/articles/simd-parsing-int-sequences.html
+  uint16x8_t const t0 = vsubq_u16(data, vmovq_n_u16('0'));
+  uint16x8_t const mask = vcltq_u16(t0, vmovq_n_u16('9' - '0' + 1));
+
+  if (vminvq_u16(mask) == 0xFFFF) {
+    i = i * 100000000 + parse_eight_digits_unrolled(simd_read8_to_u64(data));
+    return true;
+  } else
+    return false;
+  FASTFLOAT_SIMD_RESTORE_WARNINGS
+#else
+  (void)chars;
+  (void)i;
+  return false;
+#endif // FASTFLOAT_SSE2
+}
+
+#endif // FASTFLOAT_HAS_SIMD
+
+// MSVC SFINAE is broken pre-VS2017
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+template <typename UC>
+#else
+template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>()) = 0>
+#endif
+// dummy for compile
+bool simd_parse_if_eight_digits_unrolled(UC const *, uint64_t &) {
+  return 0;
+}
+
+template <typename UC, FASTFLOAT_ENABLE_IF(!tinyobj_ff::is_same<UC, char>::value) = 0>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
+loop_parse_if_eight_digits(UC const *&p, UC const *const pend, uint64_t &i) {
+  if (!has_simd_opt<UC>()) {
+    return;
+  }
+  while ((tinyobj_ff::distance(p, pend) >= 8) &&
+         simd_parse_if_eight_digits_unrolled(
+             p, i)) { // in rare cases, this will overflow, but that's ok
+    p += 8;
+  }
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
+loop_parse_if_eight_digits(char const *&p, char const *const pend,
+                           uint64_t &i) {
+  // optimizes better than parse_if_eight_digits_unrolled() for UC = char.
+  while ((tinyobj_ff::distance(p, pend) >= 8) &&
+         is_made_of_eight_digits_fast(read8_to_u64(p))) {
+    i = i * 100000000 +
+        parse_eight_digits_unrolled(read8_to_u64(
+            p)); // in rare cases, this will overflow, but that's ok
+    p += 8;
+  }
+}
+
+enum class parse_error {
+  no_error,
+  // [JSON-only] The minus sign must be followed by an integer.
+  missing_integer_after_sign,
+  // A sign must be followed by an integer or dot.
+  missing_integer_or_dot_after_sign,
+  // [JSON-only] The integer part must not have leading zeros.
+  leading_zeros_in_integer_part,
+  // [JSON-only] The integer part must have at least one digit.
+  no_digits_in_integer_part,
+  // [JSON-only] If there is a decimal point, there must be digits in the
+  // fractional part.
+  no_digits_in_fractional_part,
+  // The mantissa must have at least one digit.
+  no_digits_in_mantissa,
+  // Scientific notation requires an exponential part.
+  missing_exponential_part,
+};
+
+template <typename UC> struct parsed_number_string_t {
+  int64_t exponent{0};
+  uint64_t mantissa{0};
+  UC const *lastmatch{nullptr};
+  bool negative{false};
+  bool valid{false};
+  bool too_many_digits{false};
+  // contains the range of the significant digits
+  span<UC const> integer{};  // non-nullable
+  span<UC const> fraction{}; // nullable
+  parse_error error{parse_error::no_error};
+};
+
+using byte_span = span<char const>;
+using parsed_number_string = parsed_number_string_t<char>;
+
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 parsed_number_string_t<UC>
+report_parse_error(UC const *p, parse_error error) {
+  parsed_number_string_t<UC> answer;
+  answer.valid = false;
+  answer.lastmatch = p;
+  answer.error = error;
+  return answer;
+}
+
+// Assuming that you use no more than 19 digits, this will
+// parse an ASCII string.
+template <bool basic_json_fmt, typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 parsed_number_string_t<UC>
+parse_number_string(UC const *p, UC const *pend,
+                    parse_options_t<UC> options) noexcept {
+  chars_format const fmt = detail::adjust_for_feature_macros(options.format);
+  UC const decimal_point = options.decimal_point;
+
+  parsed_number_string_t<UC> answer;
+  answer.valid = false;
+  answer.too_many_digits = false;
+  // assume p < pend, so dereference without checks;
+  answer.negative = (*p == UC('-'));
+  // C++17 20.19.3.(7.1) explicitly forbids '+' sign here
+  if ((*p == UC('-')) || (uint64_t(fmt & chars_format::allow_leading_plus) &&
+                          !basic_json_fmt && *p == UC('+'))) {
+    ++p;
+    if (p == pend) {
+      return report_parse_error<UC>(
+          p, parse_error::missing_integer_or_dot_after_sign);
+    }
+    FASTFLOAT_IF_CONSTEXPR17(basic_json_fmt) {
+      if (!is_integer(*p)) { // a sign must be followed by an integer
+        return report_parse_error<UC>(p,
+                                      parse_error::missing_integer_after_sign);
+      }
+    }
+    else {
+      if (!is_integer(*p) &&
+          (*p !=
+           decimal_point)) { // a sign must be followed by an integer or the dot
+        return report_parse_error<UC>(
+            p, parse_error::missing_integer_or_dot_after_sign);
+      }
+    }
+  }
+  UC const *const start_digits = p;
+
+  uint64_t i = 0; // an unsigned int avoids signed overflows (which are bad)
+
+  while ((p != pend) && is_integer(*p)) {
+    // a multiplication by 10 is cheaper than an arbitrary integer
+    // multiplication
+    i = 10 * i +
+        uint64_t(*p -
+                 UC('0')); // might overflow, we will handle the overflow later
+    ++p;
+  }
+  UC const *const end_of_integer_part = p;
+  int64_t digit_count = int64_t(end_of_integer_part - start_digits);
+  answer.integer = span<UC const>(start_digits, size_t(digit_count));
+  FASTFLOAT_IF_CONSTEXPR17(basic_json_fmt) {
+    // at least 1 digit in integer part, without leading zeros
+    if (digit_count == 0) {
+      return report_parse_error<UC>(p, parse_error::no_digits_in_integer_part);
+    }
+    if ((start_digits[0] == UC('0') && digit_count > 1)) {
+      return report_parse_error<UC>(start_digits,
+                                    parse_error::leading_zeros_in_integer_part);
+    }
+  }
+
+  int64_t exponent = 0;
+  bool const has_decimal_point = (p != pend) && (*p == decimal_point);
+  if (has_decimal_point) {
+    ++p;
+    UC const *before = p;
+    // can occur at most twice without overflowing, but let it occur more, since
+    // for integers with many digits, digit parsing is the primary bottleneck.
+    loop_parse_if_eight_digits(p, pend, i);
+
+    while ((p != pend) && is_integer(*p)) {
+      uint8_t digit = uint8_t(*p - UC('0'));
+      ++p;
+      i = i * 10 + digit; // in rare cases, this will overflow, but that's ok
+    }
+    exponent = before - p;
+    answer.fraction = span<UC const>(before, size_t(p - before));
+    digit_count -= exponent;
+  }
+  FASTFLOAT_IF_CONSTEXPR17(basic_json_fmt) {
+    // at least 1 digit in fractional part
+    if (has_decimal_point && exponent == 0) {
+      return report_parse_error<UC>(p,
+                                    parse_error::no_digits_in_fractional_part);
+    }
+  }
+  else if (digit_count == 0) { // we must have encountered at least one integer!
+    return report_parse_error<UC>(p, parse_error::no_digits_in_mantissa);
+  }
+  int64_t exp_number = 0; // explicit exponential part
+  if ((uint64_t(fmt & chars_format::scientific) && (p != pend) &&
+       ((UC('e') == *p) || (UC('E') == *p))) ||
+      (uint64_t(fmt & detail::basic_fortran_fmt) && (p != pend) &&
+       ((UC('+') == *p) || (UC('-') == *p) || (UC('d') == *p) ||
+        (UC('D') == *p)))) {
+    UC const *location_of_e = p;
+    if ((UC('e') == *p) || (UC('E') == *p) || (UC('d') == *p) ||
+        (UC('D') == *p)) {
+      ++p;
+    }
+    bool neg_exp = false;
+    if ((p != pend) && (UC('-') == *p)) {
+      neg_exp = true;
+      ++p;
+    } else if ((p != pend) &&
+               (UC('+') ==
+                *p)) { // '+' on exponent is allowed by C++17 20.19.3.(7.1)
+      ++p;
+    }
+    if ((p == pend) || !is_integer(*p)) {
+      if (!uint64_t(fmt & chars_format::fixed)) {
+        // The exponential part is invalid for scientific notation, so it must
+        // be a trailing token for fixed notation. However, fixed notation is
+        // disabled, so report a scientific notation error.
+        return report_parse_error<UC>(p, parse_error::missing_exponential_part);
+      }
+      // Otherwise, we will be ignoring the 'e'.
+      p = location_of_e;
+    } else {
+      while ((p != pend) && is_integer(*p)) {
+        uint8_t digit = uint8_t(*p - UC('0'));
+        if (exp_number < 0x10000000) {
+          exp_number = 10 * exp_number + digit;
+        }
+        ++p;
+      }
+      if (neg_exp) {
+        exp_number = -exp_number;
+      }
+      exponent += exp_number;
+    }
+  } else {
+    // If it scientific and not fixed, we have to bail out.
+    if (uint64_t(fmt & chars_format::scientific) &&
+        !uint64_t(fmt & chars_format::fixed)) {
+      return report_parse_error<UC>(p, parse_error::missing_exponential_part);
+    }
+  }
+  answer.lastmatch = p;
+  answer.valid = true;
+
+  // If we frequently had to deal with long strings of digits,
+  // we could extend our code by using a 128-bit integer instead
+  // of a 64-bit integer. However, this is uncommon.
+  //
+  // We can deal with up to 19 digits.
+  if (digit_count > 19) { // this is uncommon
+    // It is possible that the integer had an overflow.
+    // We have to handle the case where we have 0.0000somenumber.
+    // We need to be mindful of the case where we only have zeroes...
+    // E.g., 0.000000000...000.
+    UC const *start = start_digits;
+    while ((start != pend) && (*start == UC('0') || *start == decimal_point)) {
+      if (*start == UC('0')) {
+        digit_count--;
+      }
+      start++;
+    }
+
+    if (digit_count > 19) {
+      answer.too_many_digits = true;
+      // Let us start again, this time, avoiding overflows.
+      // We don't need to check if is_integer, since we use the
+      // pre-tokenized spans from above.
+      i = 0;
+      p = answer.integer.ptr;
+      UC const *int_end = p + answer.integer.len();
+      uint64_t const minimal_nineteen_digit_integer{1000000000000000000};
+      while ((i < minimal_nineteen_digit_integer) && (p != int_end)) {
+        i = i * 10 + uint64_t(*p - UC('0'));
+        ++p;
+      }
+      if (i >= minimal_nineteen_digit_integer) { // We have a big integers
+        exponent = end_of_integer_part - p + exp_number;
+      } else { // We have a value with a fractional component.
+        p = answer.fraction.ptr;
+        UC const *frac_end = p + answer.fraction.len();
+        while ((i < minimal_nineteen_digit_integer) && (p != frac_end)) {
+          i = i * 10 + uint64_t(*p - UC('0'));
+          ++p;
+        }
+        exponent = answer.fraction.ptr - p + exp_number;
+      }
+      // We have now corrected both exponent and i, to a truncated value
+    }
+  }
+  answer.exponent = exponent;
+  answer.mantissa = i;
+  return answer;
+}
+
+template <typename T, typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+parse_int_string(UC const *p, UC const *pend, T &value,
+                 parse_options_t<UC> options) {
+  chars_format const fmt = detail::adjust_for_feature_macros(options.format);
+  int const base = options.base;
+
+  from_chars_result_t<UC> answer;
+
+  UC const *const first = p;
+
+  bool const negative = (*p == UC('-'));
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#endif
+  if (!tinyobj_ff::is_signed<T>::value && negative) {
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(pop)
+#endif
+    answer.ec = tinyobj_ff::ff_errc::invalid_argument;
+    answer.ptr = first;
+    return answer;
+  }
+  if ((*p == UC('-')) ||
+      (uint64_t(fmt & chars_format::allow_leading_plus) && (*p == UC('+')))) {
+    ++p;
+  }
+
+  UC const *const start_num = p;
+
+  while (p != pend && *p == UC('0')) {
+    ++p;
+  }
+
+  bool const has_leading_zeros = p > start_num;
+
+  UC const *const start_digits = p;
+
+  uint64_t i = 0;
+  if (base == 10) {
+    loop_parse_if_eight_digits(p, pend, i); // use SIMD if possible
+  }
+  while (p != pend) {
+    uint8_t digit = ch_to_digit(*p);
+    if (digit >= base) {
+      break;
+    }
+    i = uint64_t(base) * i + digit; // might overflow, check this later
+    p++;
+  }
+
+  size_t digit_count = size_t(p - start_digits);
+
+  if (digit_count == 0) {
+    if (has_leading_zeros) {
+      value = 0;
+      answer.ec = tinyobj_ff::ff_errc();
+      answer.ptr = p;
+    } else {
+      answer.ec = tinyobj_ff::ff_errc::invalid_argument;
+      answer.ptr = first;
+    }
+    return answer;
+  }
+
+  answer.ptr = p;
+
+  // check u64 overflow
+  size_t max_digits = max_digits_u64(base);
+  if (digit_count > max_digits) {
+    answer.ec = tinyobj_ff::ff_errc::result_out_of_range;
+    return answer;
+  }
+  // this check can be eliminated for all other types, but they will all require
+  // a max_digits(base) equivalent
+  if (digit_count == max_digits && i < min_safe_u64(base)) {
+    answer.ec = tinyobj_ff::ff_errc::result_out_of_range;
+    return answer;
+  }
+
+  // check other types overflow
+  if (!tinyobj_ff::is_same<T, uint64_t>::value) {
+    if (i > uint64_t(std::numeric_limits<T>::max()) + uint64_t(negative)) {
+      answer.ec = tinyobj_ff::ff_errc::result_out_of_range;
+      return answer;
+    }
+  }
+
+  if (negative) {
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(push)
+#pragma warning(disable : 4146)
+#endif
+    // this weird workaround is required because:
+    // - converting unsigned to signed when its value is greater than signed max
+    // is UB pre-C++23.
+    // - reinterpret_casting (~i + 1) would work, but it is not constexpr
+    // this is always optimized into a neg instruction (note: T is an integer
+    // type)
+    value = T(-std::numeric_limits<T>::max() -
+              T(i - uint64_t(std::numeric_limits<T>::max())));
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(pop)
+#endif
+  } else {
+    value = T(i);
+  }
+
+  answer.ec = tinyobj_ff::ff_errc();
+  return answer;
+}
+
+} // namespace fast_float
+
+#endif
+
+#ifndef FASTFLOAT_FAST_TABLE_H
+#define FASTFLOAT_FAST_TABLE_H
+
+namespace fast_float {
+
+/**
+ * When mapping numbers from decimal to binary,
+ * we go from w * 10^q to m * 2^p but we have
+ * 10^q = 5^q * 2^q, so effectively
+ * we are trying to match
+ * w * 2^q * 5^q to m * 2^p. Thus the powers of two
+ * are not a concern since they can be represented
+ * exactly using the binary notation, only the powers of five
+ * affect the binary significand.
+ */
+
+/**
+ * The smallest non-zero float (binary64) is 2^-1074.
+ * We take as input numbers of the form w x 10^q where w < 2^64.
+ * We have that w * 10^-343  <  2^(64-344) 5^-343 < 2^-1076.
+ * However, we have that
+ * (2^64-1) * 10^-342 =  (2^64-1) * 2^-342 * 5^-342 > 2^-1074.
+ * Thus it is possible for a number of the form w * 10^-342 where
+ * w is a 64-bit value to be a non-zero floating-point number.
+ *********
+ * Any number of form w * 10^309 where w>= 1 is going to be
+ * infinite in binary64 so we never need to worry about powers
+ * of 5 greater than 308.
+ */
+template <class unused = void> struct powers_template {
+
+  constexpr static int smallest_power_of_five =
+      binary_format<double>::smallest_power_of_ten();
+  constexpr static int largest_power_of_five =
+      binary_format<double>::largest_power_of_ten();
+  constexpr static int number_of_entries =
+      2 * (largest_power_of_five - smallest_power_of_five + 1);
+  // Powers of five from 5^-342 all the way to 5^308 rounded toward one.
+  constexpr static uint64_t power_of_five_128[number_of_entries] = {
+      0xeef453d6923bd65a, 0x113faa2906a13b3f,
+      0x9558b4661b6565f8, 0x4ac7ca59a424c507,
+      0xbaaee17fa23ebf76, 0x5d79bcf00d2df649,
+      0xe95a99df8ace6f53, 0xf4d82c2c107973dc,
+      0x91d8a02bb6c10594, 0x79071b9b8a4be869,
+      0xb64ec836a47146f9, 0x9748e2826cdee284,
+      0xe3e27a444d8d98b7, 0xfd1b1b2308169b25,
+      0x8e6d8c6ab0787f72, 0xfe30f0f5e50e20f7,
+      0xb208ef855c969f4f, 0xbdbd2d335e51a935,
+      0xde8b2b66b3bc4723, 0xad2c788035e61382,
+      0x8b16fb203055ac76, 0x4c3bcb5021afcc31,
+      0xaddcb9e83c6b1793, 0xdf4abe242a1bbf3d,
+      0xd953e8624b85dd78, 0xd71d6dad34a2af0d,
+      0x87d4713d6f33aa6b, 0x8672648c40e5ad68,
+      0xa9c98d8ccb009506, 0x680efdaf511f18c2,
+      0xd43bf0effdc0ba48, 0x212bd1b2566def2,
+      0x84a57695fe98746d, 0x14bb630f7604b57,
+      0xa5ced43b7e3e9188, 0x419ea3bd35385e2d,
+      0xcf42894a5dce35ea, 0x52064cac828675b9,
+      0x818995ce7aa0e1b2, 0x7343efebd1940993,
+      0xa1ebfb4219491a1f, 0x1014ebe6c5f90bf8,
+      0xca66fa129f9b60a6, 0xd41a26e077774ef6,
+      0xfd00b897478238d0, 0x8920b098955522b4,
+      0x9e20735e8cb16382, 0x55b46e5f5d5535b0,
+      0xc5a890362fddbc62, 0xeb2189f734aa831d,
+      0xf712b443bbd52b7b, 0xa5e9ec7501d523e4,
+      0x9a6bb0aa55653b2d, 0x47b233c92125366e,
+      0xc1069cd4eabe89f8, 0x999ec0bb696e840a,
+      0xf148440a256e2c76, 0xc00670ea43ca250d,
+      0x96cd2a865764dbca, 0x380406926a5e5728,
+      0xbc807527ed3e12bc, 0xc605083704f5ecf2,
+      0xeba09271e88d976b, 0xf7864a44c633682e,
+      0x93445b8731587ea3, 0x7ab3ee6afbe0211d,
+      0xb8157268fdae9e4c, 0x5960ea05bad82964,
+      0xe61acf033d1a45df, 0x6fb92487298e33bd,
+      0x8fd0c16206306bab, 0xa5d3b6d479f8e056,
+      0xb3c4f1ba87bc8696, 0x8f48a4899877186c,
+      0xe0b62e2929aba83c, 0x331acdabfe94de87,
+      0x8c71dcd9ba0b4925, 0x9ff0c08b7f1d0b14,
+      0xaf8e5410288e1b6f, 0x7ecf0ae5ee44dd9,
+      0xdb71e91432b1a24a, 0xc9e82cd9f69d6150,
+      0x892731ac9faf056e, 0xbe311c083a225cd2,
+      0xab70fe17c79ac6ca, 0x6dbd630a48aaf406,
+      0xd64d3d9db981787d, 0x92cbbccdad5b108,
+      0x85f0468293f0eb4e, 0x25bbf56008c58ea5,
+      0xa76c582338ed2621, 0xaf2af2b80af6f24e,
+      0xd1476e2c07286faa, 0x1af5af660db4aee1,
+      0x82cca4db847945ca, 0x50d98d9fc890ed4d,
+      0xa37fce126597973c, 0xe50ff107bab528a0,
+      0xcc5fc196fefd7d0c, 0x1e53ed49a96272c8,
+      0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7a,
+      0x9faacf3df73609b1, 0x77b191618c54e9ac,
+      0xc795830d75038c1d, 0xd59df5b9ef6a2417,
+      0xf97ae3d0d2446f25, 0x4b0573286b44ad1d,
+      0x9becce62836ac577, 0x4ee367f9430aec32,
+      0xc2e801fb244576d5, 0x229c41f793cda73f,
+      0xf3a20279ed56d48a, 0x6b43527578c1110f,
+      0x9845418c345644d6, 0x830a13896b78aaa9,
+      0xbe5691ef416bd60c, 0x23cc986bc656d553,
+      0xedec366b11c6cb8f, 0x2cbfbe86b7ec8aa8,
+      0x94b3a202eb1c3f39, 0x7bf7d71432f3d6a9,
+      0xb9e08a83a5e34f07, 0xdaf5ccd93fb0cc53,
+      0xe858ad248f5c22c9, 0xd1b3400f8f9cff68,
+      0x91376c36d99995be, 0x23100809b9c21fa1,
+      0xb58547448ffffb2d, 0xabd40a0c2832a78a,
+      0xe2e69915b3fff9f9, 0x16c90c8f323f516c,
+      0x8dd01fad907ffc3b, 0xae3da7d97f6792e3,
+      0xb1442798f49ffb4a, 0x99cd11cfdf41779c,
+      0xdd95317f31c7fa1d, 0x40405643d711d583,
+      0x8a7d3eef7f1cfc52, 0x482835ea666b2572,
+      0xad1c8eab5ee43b66, 0xda3243650005eecf,
+      0xd863b256369d4a40, 0x90bed43e40076a82,
+      0x873e4f75e2224e68, 0x5a7744a6e804a291,
+      0xa90de3535aaae202, 0x711515d0a205cb36,
+      0xd3515c2831559a83, 0xd5a5b44ca873e03,
+      0x8412d9991ed58091, 0xe858790afe9486c2,
+      0xa5178fff668ae0b6, 0x626e974dbe39a872,
+      0xce5d73ff402d98e3, 0xfb0a3d212dc8128f,
+      0x80fa687f881c7f8e, 0x7ce66634bc9d0b99,
+      0xa139029f6a239f72, 0x1c1fffc1ebc44e80,
+      0xc987434744ac874e, 0xa327ffb266b56220,
+      0xfbe9141915d7a922, 0x4bf1ff9f0062baa8,
+      0x9d71ac8fada6c9b5, 0x6f773fc3603db4a9,
+      0xc4ce17b399107c22, 0xcb550fb4384d21d3,
+      0xf6019da07f549b2b, 0x7e2a53a146606a48,
+      0x99c102844f94e0fb, 0x2eda7444cbfc426d,
+      0xc0314325637a1939, 0xfa911155fefb5308,
+      0xf03d93eebc589f88, 0x793555ab7eba27ca,
+      0x96267c7535b763b5, 0x4bc1558b2f3458de,
+      0xbbb01b9283253ca2, 0x9eb1aaedfb016f16,
+      0xea9c227723ee8bcb, 0x465e15a979c1cadc,
+      0x92a1958a7675175f, 0xbfacd89ec191ec9,
+      0xb749faed14125d36, 0xcef980ec671f667b,
+      0xe51c79a85916f484, 0x82b7e12780e7401a,
+      0x8f31cc0937ae58d2, 0xd1b2ecb8b0908810,
+      0xb2fe3f0b8599ef07, 0x861fa7e6dcb4aa15,
+      0xdfbdcece67006ac9, 0x67a791e093e1d49a,
+      0x8bd6a141006042bd, 0xe0c8bb2c5c6d24e0,
+      0xaecc49914078536d, 0x58fae9f773886e18,
+      0xda7f5bf590966848, 0xaf39a475506a899e,
+      0x888f99797a5e012d, 0x6d8406c952429603,
+      0xaab37fd7d8f58178, 0xc8e5087ba6d33b83,
+      0xd5605fcdcf32e1d6, 0xfb1e4a9a90880a64,
+      0x855c3be0a17fcd26, 0x5cf2eea09a55067f,
+      0xa6b34ad8c9dfc06f, 0xf42faa48c0ea481e,
+      0xd0601d8efc57b08b, 0xf13b94daf124da26,
+      0x823c12795db6ce57, 0x76c53d08d6b70858,
+      0xa2cb1717b52481ed, 0x54768c4b0c64ca6e,
+      0xcb7ddcdda26da268, 0xa9942f5dcf7dfd09,
+      0xfe5d54150b090b02, 0xd3f93b35435d7c4c,
+      0x9efa548d26e5a6e1, 0xc47bc5014a1a6daf,
+      0xc6b8e9b0709f109a, 0x359ab6419ca1091b,
+      0xf867241c8cc6d4c0, 0xc30163d203c94b62,
+      0x9b407691d7fc44f8, 0x79e0de63425dcf1d,
+      0xc21094364dfb5636, 0x985915fc12f542e4,
+      0xf294b943e17a2bc4, 0x3e6f5b7b17b2939d,
+      0x979cf3ca6cec5b5a, 0xa705992ceecf9c42,
+      0xbd8430bd08277231, 0x50c6ff782a838353,
+      0xece53cec4a314ebd, 0xa4f8bf5635246428,
+      0x940f4613ae5ed136, 0x871b7795e136be99,
+      0xb913179899f68584, 0x28e2557b59846e3f,
+      0xe757dd7ec07426e5, 0x331aeada2fe589cf,
+      0x9096ea6f3848984f, 0x3ff0d2c85def7621,
+      0xb4bca50b065abe63, 0xfed077a756b53a9,
+      0xe1ebce4dc7f16dfb, 0xd3e8495912c62894,
+      0x8d3360f09cf6e4bd, 0x64712dd7abbbd95c,
+      0xb080392cc4349dec, 0xbd8d794d96aacfb3,
+      0xdca04777f541c567, 0xecf0d7a0fc5583a0,
+      0x89e42caaf9491b60, 0xf41686c49db57244,
+      0xac5d37d5b79b6239, 0x311c2875c522ced5,
+      0xd77485cb25823ac7, 0x7d633293366b828b,
+      0x86a8d39ef77164bc, 0xae5dff9c02033197,
+      0xa8530886b54dbdeb, 0xd9f57f830283fdfc,
+      0xd267caa862a12d66, 0xd072df63c324fd7b,
+      0x8380dea93da4bc60, 0x4247cb9e59f71e6d,
+      0xa46116538d0deb78, 0x52d9be85f074e608,
+      0xcd795be870516656, 0x67902e276c921f8b,
+      0x806bd9714632dff6, 0xba1cd8a3db53b6,
+      0xa086cfcd97bf97f3, 0x80e8a40eccd228a4,
+      0xc8a883c0fdaf7df0, 0x6122cd128006b2cd,
+      0xfad2a4b13d1b5d6c, 0x796b805720085f81,
+      0x9cc3a6eec6311a63, 0xcbe3303674053bb0,
+      0xc3f490aa77bd60fc, 0xbedbfc4411068a9c,
+      0xf4f1b4d515acb93b, 0xee92fb5515482d44,
+      0x991711052d8bf3c5, 0x751bdd152d4d1c4a,
+      0xbf5cd54678eef0b6, 0xd262d45a78a0635d,
+      0xef340a98172aace4, 0x86fb897116c87c34,
+      0x9580869f0e7aac0e, 0xd45d35e6ae3d4da0,
+      0xbae0a846d2195712, 0x8974836059cca109,
+      0xe998d258869facd7, 0x2bd1a438703fc94b,
+      0x91ff83775423cc06, 0x7b6306a34627ddcf,
+      0xb67f6455292cbf08, 0x1a3bc84c17b1d542,
+      0xe41f3d6a7377eeca, 0x20caba5f1d9e4a93,
+      0x8e938662882af53e, 0x547eb47b7282ee9c,
+      0xb23867fb2a35b28d, 0xe99e619a4f23aa43,
+      0xdec681f9f4c31f31, 0x6405fa00e2ec94d4,
+      0x8b3c113c38f9f37e, 0xde83bc408dd3dd04,
+      0xae0b158b4738705e, 0x9624ab50b148d445,
+      0xd98ddaee19068c76, 0x3badd624dd9b0957,
+      0x87f8a8d4cfa417c9, 0xe54ca5d70a80e5d6,
+      0xa9f6d30a038d1dbc, 0x5e9fcf4ccd211f4c,
+      0xd47487cc8470652b, 0x7647c3200069671f,
+      0x84c8d4dfd2c63f3b, 0x29ecd9f40041e073,
+      0xa5fb0a17c777cf09, 0xf468107100525890,
+      0xcf79cc9db955c2cc, 0x7182148d4066eeb4,
+      0x81ac1fe293d599bf, 0xc6f14cd848405530,
+      0xa21727db38cb002f, 0xb8ada00e5a506a7c,
+      0xca9cf1d206fdc03b, 0xa6d90811f0e4851c,
+      0xfd442e4688bd304a, 0x908f4a166d1da663,
+      0x9e4a9cec15763e2e, 0x9a598e4e043287fe,
+      0xc5dd44271ad3cdba, 0x40eff1e1853f29fd,
+      0xf7549530e188c128, 0xd12bee59e68ef47c,
+      0x9a94dd3e8cf578b9, 0x82bb74f8301958ce,
+      0xc13a148e3032d6e7, 0xe36a52363c1faf01,
+      0xf18899b1bc3f8ca1, 0xdc44e6c3cb279ac1,
+      0x96f5600f15a7b7e5, 0x29ab103a5ef8c0b9,
+      0xbcb2b812db11a5de, 0x7415d448f6b6f0e7,
+      0xebdf661791d60f56, 0x111b495b3464ad21,
+      0x936b9fcebb25c995, 0xcab10dd900beec34,
+      0xb84687c269ef3bfb, 0x3d5d514f40eea742,
+      0xe65829b3046b0afa, 0xcb4a5a3112a5112,
+      0x8ff71a0fe2c2e6dc, 0x47f0e785eaba72ab,
+      0xb3f4e093db73a093, 0x59ed216765690f56,
+      0xe0f218b8d25088b8, 0x306869c13ec3532c,
+      0x8c974f7383725573, 0x1e414218c73a13fb,
+      0xafbd2350644eeacf, 0xe5d1929ef90898fa,
+      0xdbac6c247d62a583, 0xdf45f746b74abf39,
+      0x894bc396ce5da772, 0x6b8bba8c328eb783,
+      0xab9eb47c81f5114f, 0x66ea92f3f326564,
+      0xd686619ba27255a2, 0xc80a537b0efefebd,
+      0x8613fd0145877585, 0xbd06742ce95f5f36,
+      0xa798fc4196e952e7, 0x2c48113823b73704,
+      0xd17f3b51fca3a7a0, 0xf75a15862ca504c5,
+      0x82ef85133de648c4, 0x9a984d73dbe722fb,
+      0xa3ab66580d5fdaf5, 0xc13e60d0d2e0ebba,
+      0xcc963fee10b7d1b3, 0x318df905079926a8,
+      0xffbbcfe994e5c61f, 0xfdf17746497f7052,
+      0x9fd561f1fd0f9bd3, 0xfeb6ea8bedefa633,
+      0xc7caba6e7c5382c8, 0xfe64a52ee96b8fc0,
+      0xf9bd690a1b68637b, 0x3dfdce7aa3c673b0,
+      0x9c1661a651213e2d, 0x6bea10ca65c084e,
+      0xc31bfa0fe5698db8, 0x486e494fcff30a62,
+      0xf3e2f893dec3f126, 0x5a89dba3c3efccfa,
+      0x986ddb5c6b3a76b7, 0xf89629465a75e01c,
+      0xbe89523386091465, 0xf6bbb397f1135823,
+      0xee2ba6c0678b597f, 0x746aa07ded582e2c,
+      0x94db483840b717ef, 0xa8c2a44eb4571cdc,
+      0xba121a4650e4ddeb, 0x92f34d62616ce413,
+      0xe896a0d7e51e1566, 0x77b020baf9c81d17,
+      0x915e2486ef32cd60, 0xace1474dc1d122e,
+      0xb5b5ada8aaff80b8, 0xd819992132456ba,
+      0xe3231912d5bf60e6, 0x10e1fff697ed6c69,
+      0x8df5efabc5979c8f, 0xca8d3ffa1ef463c1,
+      0xb1736b96b6fd83b3, 0xbd308ff8a6b17cb2,
+      0xddd0467c64bce4a0, 0xac7cb3f6d05ddbde,
+      0x8aa22c0dbef60ee4, 0x6bcdf07a423aa96b,
+      0xad4ab7112eb3929d, 0x86c16c98d2c953c6,
+      0xd89d64d57a607744, 0xe871c7bf077ba8b7,
+      0x87625f056c7c4a8b, 0x11471cd764ad4972,
+      0xa93af6c6c79b5d2d, 0xd598e40d3dd89bcf,
+      0xd389b47879823479, 0x4aff1d108d4ec2c3,
+      0x843610cb4bf160cb, 0xcedf722a585139ba,
+      0xa54394fe1eedb8fe, 0xc2974eb4ee658828,
+      0xce947a3da6a9273e, 0x733d226229feea32,
+      0x811ccc668829b887, 0x806357d5a3f525f,
+      0xa163ff802a3426a8, 0xca07c2dcb0cf26f7,
+      0xc9bcff6034c13052, 0xfc89b393dd02f0b5,
+      0xfc2c3f3841f17c67, 0xbbac2078d443ace2,
+      0x9d9ba7832936edc0, 0xd54b944b84aa4c0d,
+      0xc5029163f384a931, 0xa9e795e65d4df11,
+      0xf64335bcf065d37d, 0x4d4617b5ff4a16d5,
+      0x99ea0196163fa42e, 0x504bced1bf8e4e45,
+      0xc06481fb9bcf8d39, 0xe45ec2862f71e1d6,
+      0xf07da27a82c37088, 0x5d767327bb4e5a4c,
+      0x964e858c91ba2655, 0x3a6a07f8d510f86f,
+      0xbbe226efb628afea, 0x890489f70a55368b,
+      0xeadab0aba3b2dbe5, 0x2b45ac74ccea842e,
+      0x92c8ae6b464fc96f, 0x3b0b8bc90012929d,
+      0xb77ada0617e3bbcb, 0x9ce6ebb40173744,
+      0xe55990879ddcaabd, 0xcc420a6a101d0515,
+      0x8f57fa54c2a9eab6, 0x9fa946824a12232d,
+      0xb32df8e9f3546564, 0x47939822dc96abf9,
+      0xdff9772470297ebd, 0x59787e2b93bc56f7,
+      0x8bfbea76c619ef36, 0x57eb4edb3c55b65a,
+      0xaefae51477a06b03, 0xede622920b6b23f1,
+      0xdab99e59958885c4, 0xe95fab368e45eced,
+      0x88b402f7fd75539b, 0x11dbcb0218ebb414,
+      0xaae103b5fcd2a881, 0xd652bdc29f26a119,
+      0xd59944a37c0752a2, 0x4be76d3346f0495f,
+      0x857fcae62d8493a5, 0x6f70a4400c562ddb,
+      0xa6dfbd9fb8e5b88e, 0xcb4ccd500f6bb952,
+      0xd097ad07a71f26b2, 0x7e2000a41346a7a7,
+      0x825ecc24c873782f, 0x8ed400668c0c28c8,
+      0xa2f67f2dfa90563b, 0x728900802f0f32fa,
+      0xcbb41ef979346bca, 0x4f2b40a03ad2ffb9,
+      0xfea126b7d78186bc, 0xe2f610c84987bfa8,
+      0x9f24b832e6b0f436, 0xdd9ca7d2df4d7c9,
+      0xc6ede63fa05d3143, 0x91503d1c79720dbb,
+      0xf8a95fcf88747d94, 0x75a44c6397ce912a,
+      0x9b69dbe1b548ce7c, 0xc986afbe3ee11aba,
+      0xc24452da229b021b, 0xfbe85badce996168,
+      0xf2d56790ab41c2a2, 0xfae27299423fb9c3,
+      0x97c560ba6b0919a5, 0xdccd879fc967d41a,
+      0xbdb6b8e905cb600f, 0x5400e987bbc1c920,
+      0xed246723473e3813, 0x290123e9aab23b68,
+      0x9436c0760c86e30b, 0xf9a0b6720aaf6521,
+      0xb94470938fa89bce, 0xf808e40e8d5b3e69,
+      0xe7958cb87392c2c2, 0xb60b1d1230b20e04,
+      0x90bd77f3483bb9b9, 0xb1c6f22b5e6f48c2,
+      0xb4ecd5f01a4aa828, 0x1e38aeb6360b1af3,
+      0xe2280b6c20dd5232, 0x25c6da63c38de1b0,
+      0x8d590723948a535f, 0x579c487e5a38ad0e,
+      0xb0af48ec79ace837, 0x2d835a9df0c6d851,
+      0xdcdb1b2798182244, 0xf8e431456cf88e65,
+      0x8a08f0f8bf0f156b, 0x1b8e9ecb641b58ff,
+      0xac8b2d36eed2dac5, 0xe272467e3d222f3f,
+      0xd7adf884aa879177, 0x5b0ed81dcc6abb0f,
+      0x86ccbb52ea94baea, 0x98e947129fc2b4e9,
+      0xa87fea27a539e9a5, 0x3f2398d747b36224,
+      0xd29fe4b18e88640e, 0x8eec7f0d19a03aad,
+      0x83a3eeeef9153e89, 0x1953cf68300424ac,
+      0xa48ceaaab75a8e2b, 0x5fa8c3423c052dd7,
+      0xcdb02555653131b6, 0x3792f412cb06794d,
+      0x808e17555f3ebf11, 0xe2bbd88bbee40bd0,
+      0xa0b19d2ab70e6ed6, 0x5b6aceaeae9d0ec4,
+      0xc8de047564d20a8b, 0xf245825a5a445275,
+      0xfb158592be068d2e, 0xeed6e2f0f0d56712,
+      0x9ced737bb6c4183d, 0x55464dd69685606b,
+      0xc428d05aa4751e4c, 0xaa97e14c3c26b886,
+      0xf53304714d9265df, 0xd53dd99f4b3066a8,
+      0x993fe2c6d07b7fab, 0xe546a8038efe4029,
+      0xbf8fdb78849a5f96, 0xde98520472bdd033,
+      0xef73d256a5c0f77c, 0x963e66858f6d4440,
+      0x95a8637627989aad, 0xdde7001379a44aa8,
+      0xbb127c53b17ec159, 0x5560c018580d5d52,
+      0xe9d71b689dde71af, 0xaab8f01e6e10b4a6,
+      0x9226712162ab070d, 0xcab3961304ca70e8,
+      0xb6b00d69bb55c8d1, 0x3d607b97c5fd0d22,
+      0xe45c10c42a2b3b05, 0x8cb89a7db77c506a,
+      0x8eb98a7a9a5b04e3, 0x77f3608e92adb242,
+      0xb267ed1940f1c61c, 0x55f038b237591ed3,
+      0xdf01e85f912e37a3, 0x6b6c46dec52f6688,
+      0x8b61313bbabce2c6, 0x2323ac4b3b3da015,
+      0xae397d8aa96c1b77, 0xabec975e0a0d081a,
+      0xd9c7dced53c72255, 0x96e7bd358c904a21,
+      0x881cea14545c7575, 0x7e50d64177da2e54,
+      0xaa242499697392d2, 0xdde50bd1d5d0b9e9,
+      0xd4ad2dbfc3d07787, 0x955e4ec64b44e864,
+      0x84ec3c97da624ab4, 0xbd5af13bef0b113e,
+      0xa6274bbdd0fadd61, 0xecb1ad8aeacdd58e,
+      0xcfb11ead453994ba, 0x67de18eda5814af2,
+      0x81ceb32c4b43fcf4, 0x80eacf948770ced7,
+      0xa2425ff75e14fc31, 0xa1258379a94d028d,
+      0xcad2f7f5359a3b3e, 0x96ee45813a04330,
+      0xfd87b5f28300ca0d, 0x8bca9d6e188853fc,
+      0x9e74d1b791e07e48, 0x775ea264cf55347e,
+      0xc612062576589dda, 0x95364afe032a819e,
+      0xf79687aed3eec551, 0x3a83ddbd83f52205,
+      0x9abe14cd44753b52, 0xc4926a9672793543,
+      0xc16d9a0095928a27, 0x75b7053c0f178294,
+      0xf1c90080baf72cb1, 0x5324c68b12dd6339,
+      0x971da05074da7bee, 0xd3f6fc16ebca5e04,
+      0xbce5086492111aea, 0x88f4bb1ca6bcf585,
+      0xec1e4a7db69561a5, 0x2b31e9e3d06c32e6,
+      0x9392ee8e921d5d07, 0x3aff322e62439fd0,
+      0xb877aa3236a4b449, 0x9befeb9fad487c3,
+      0xe69594bec44de15b, 0x4c2ebe687989a9b4,
+      0x901d7cf73ab0acd9, 0xf9d37014bf60a11,
+      0xb424dc35095cd80f, 0x538484c19ef38c95,
+      0xe12e13424bb40e13, 0x2865a5f206b06fba,
+      0x8cbccc096f5088cb, 0xf93f87b7442e45d4,
+      0xafebff0bcb24aafe, 0xf78f69a51539d749,
+      0xdbe6fecebdedd5be, 0xb573440e5a884d1c,
+      0x89705f4136b4a597, 0x31680a88f8953031,
+      0xabcc77118461cefc, 0xfdc20d2b36ba7c3e,
+      0xd6bf94d5e57a42bc, 0x3d32907604691b4d,
+      0x8637bd05af6c69b5, 0xa63f9a49c2c1b110,
+      0xa7c5ac471b478423, 0xfcf80dc33721d54,
+      0xd1b71758e219652b, 0xd3c36113404ea4a9,
+      0x83126e978d4fdf3b, 0x645a1cac083126ea,
+      0xa3d70a3d70a3d70a, 0x3d70a3d70a3d70a4,
+      0xcccccccccccccccc, 0xcccccccccccccccd,
+      0x8000000000000000, 0x0,
+      0xa000000000000000, 0x0,
+      0xc800000000000000, 0x0,
+      0xfa00000000000000, 0x0,
+      0x9c40000000000000, 0x0,
+      0xc350000000000000, 0x0,
+      0xf424000000000000, 0x0,
+      0x9896800000000000, 0x0,
+      0xbebc200000000000, 0x0,
+      0xee6b280000000000, 0x0,
+      0x9502f90000000000, 0x0,
+      0xba43b74000000000, 0x0,
+      0xe8d4a51000000000, 0x0,
+      0x9184e72a00000000, 0x0,
+      0xb5e620f480000000, 0x0,
+      0xe35fa931a0000000, 0x0,
+      0x8e1bc9bf04000000, 0x0,
+      0xb1a2bc2ec5000000, 0x0,
+      0xde0b6b3a76400000, 0x0,
+      0x8ac7230489e80000, 0x0,
+      0xad78ebc5ac620000, 0x0,
+      0xd8d726b7177a8000, 0x0,
+      0x878678326eac9000, 0x0,
+      0xa968163f0a57b400, 0x0,
+      0xd3c21bcecceda100, 0x0,
+      0x84595161401484a0, 0x0,
+      0xa56fa5b99019a5c8, 0x0,
+      0xcecb8f27f4200f3a, 0x0,
+      0x813f3978f8940984, 0x4000000000000000,
+      0xa18f07d736b90be5, 0x5000000000000000,
+      0xc9f2c9cd04674ede, 0xa400000000000000,
+      0xfc6f7c4045812296, 0x4d00000000000000,
+      0x9dc5ada82b70b59d, 0xf020000000000000,
+      0xc5371912364ce305, 0x6c28000000000000,
+      0xf684df56c3e01bc6, 0xc732000000000000,
+      0x9a130b963a6c115c, 0x3c7f400000000000,
+      0xc097ce7bc90715b3, 0x4b9f100000000000,
+      0xf0bdc21abb48db20, 0x1e86d40000000000,
+      0x96769950b50d88f4, 0x1314448000000000,
+      0xbc143fa4e250eb31, 0x17d955a000000000,
+      0xeb194f8e1ae525fd, 0x5dcfab0800000000,
+      0x92efd1b8d0cf37be, 0x5aa1cae500000000,
+      0xb7abc627050305ad, 0xf14a3d9e40000000,
+      0xe596b7b0c643c719, 0x6d9ccd05d0000000,
+      0x8f7e32ce7bea5c6f, 0xe4820023a2000000,
+      0xb35dbf821ae4f38b, 0xdda2802c8a800000,
+      0xe0352f62a19e306e, 0xd50b2037ad200000,
+      0x8c213d9da502de45, 0x4526f422cc340000,
+      0xaf298d050e4395d6, 0x9670b12b7f410000,
+      0xdaf3f04651d47b4c, 0x3c0cdd765f114000,
+      0x88d8762bf324cd0f, 0xa5880a69fb6ac800,
+      0xab0e93b6efee0053, 0x8eea0d047a457a00,
+      0xd5d238a4abe98068, 0x72a4904598d6d880,
+      0x85a36366eb71f041, 0x47a6da2b7f864750,
+      0xa70c3c40a64e6c51, 0x999090b65f67d924,
+      0xd0cf4b50cfe20765, 0xfff4b4e3f741cf6d,
+      0x82818f1281ed449f, 0xbff8f10e7a8921a4,
+      0xa321f2d7226895c7, 0xaff72d52192b6a0d,
+      0xcbea6f8ceb02bb39, 0x9bf4f8a69f764490,
+      0xfee50b7025c36a08, 0x2f236d04753d5b4,
+      0x9f4f2726179a2245, 0x1d762422c946590,
+      0xc722f0ef9d80aad6, 0x424d3ad2b7b97ef5,
+      0xf8ebad2b84e0d58b, 0xd2e0898765a7deb2,
+      0x9b934c3b330c8577, 0x63cc55f49f88eb2f,
+      0xc2781f49ffcfa6d5, 0x3cbf6b71c76b25fb,
+      0xf316271c7fc3908a, 0x8bef464e3945ef7a,
+      0x97edd871cfda3a56, 0x97758bf0e3cbb5ac,
+      0xbde94e8e43d0c8ec, 0x3d52eeed1cbea317,
+      0xed63a231d4c4fb27, 0x4ca7aaa863ee4bdd,
+      0x945e455f24fb1cf8, 0x8fe8caa93e74ef6a,
+      0xb975d6b6ee39e436, 0xb3e2fd538e122b44,
+      0xe7d34c64a9c85d44, 0x60dbbca87196b616,
+      0x90e40fbeea1d3a4a, 0xbc8955e946fe31cd,
+      0xb51d13aea4a488dd, 0x6babab6398bdbe41,
+      0xe264589a4dcdab14, 0xc696963c7eed2dd1,
+      0x8d7eb76070a08aec, 0xfc1e1de5cf543ca2,
+      0xb0de65388cc8ada8, 0x3b25a55f43294bcb,
+      0xdd15fe86affad912, 0x49ef0eb713f39ebe,
+      0x8a2dbf142dfcc7ab, 0x6e3569326c784337,
+      0xacb92ed9397bf996, 0x49c2c37f07965404,
+      0xd7e77a8f87daf7fb, 0xdc33745ec97be906,
+      0x86f0ac99b4e8dafd, 0x69a028bb3ded71a3,
+      0xa8acd7c0222311bc, 0xc40832ea0d68ce0c,
+      0xd2d80db02aabd62b, 0xf50a3fa490c30190,
+      0x83c7088e1aab65db, 0x792667c6da79e0fa,
+      0xa4b8cab1a1563f52, 0x577001b891185938,
+      0xcde6fd5e09abcf26, 0xed4c0226b55e6f86,
+      0x80b05e5ac60b6178, 0x544f8158315b05b4,
+      0xa0dc75f1778e39d6, 0x696361ae3db1c721,
+      0xc913936dd571c84c, 0x3bc3a19cd1e38e9,
+      0xfb5878494ace3a5f, 0x4ab48a04065c723,
+      0x9d174b2dcec0e47b, 0x62eb0d64283f9c76,
+      0xc45d1df942711d9a, 0x3ba5d0bd324f8394,
+      0xf5746577930d6500, 0xca8f44ec7ee36479,
+      0x9968bf6abbe85f20, 0x7e998b13cf4e1ecb,
+      0xbfc2ef456ae276e8, 0x9e3fedd8c321a67e,
+      0xefb3ab16c59b14a2, 0xc5cfe94ef3ea101e,
+      0x95d04aee3b80ece5, 0xbba1f1d158724a12,
+      0xbb445da9ca61281f, 0x2a8a6e45ae8edc97,
+      0xea1575143cf97226, 0xf52d09d71a3293bd,
+      0x924d692ca61be758, 0x593c2626705f9c56,
+      0xb6e0c377cfa2e12e, 0x6f8b2fb00c77836c,
+      0xe498f455c38b997a, 0xb6dfb9c0f956447,
+      0x8edf98b59a373fec, 0x4724bd4189bd5eac,
+      0xb2977ee300c50fe7, 0x58edec91ec2cb657,
+      0xdf3d5e9bc0f653e1, 0x2f2967b66737e3ed,
+      0x8b865b215899f46c, 0xbd79e0d20082ee74,
+      0xae67f1e9aec07187, 0xecd8590680a3aa11,
+      0xda01ee641a708de9, 0xe80e6f4820cc9495,
+      0x884134fe908658b2, 0x3109058d147fdcdd,
+      0xaa51823e34a7eede, 0xbd4b46f0599fd415,
+      0xd4e5e2cdc1d1ea96, 0x6c9e18ac7007c91a,
+      0x850fadc09923329e, 0x3e2cf6bc604ddb0,
+      0xa6539930bf6bff45, 0x84db8346b786151c,
+      0xcfe87f7cef46ff16, 0xe612641865679a63,
+      0x81f14fae158c5f6e, 0x4fcb7e8f3f60c07e,
+      0xa26da3999aef7749, 0xe3be5e330f38f09d,
+      0xcb090c8001ab551c, 0x5cadf5bfd3072cc5,
+      0xfdcb4fa002162a63, 0x73d9732fc7c8f7f6,
+      0x9e9f11c4014dda7e, 0x2867e7fddcdd9afa,
+      0xc646d63501a1511d, 0xb281e1fd541501b8,
+      0xf7d88bc24209a565, 0x1f225a7ca91a4226,
+      0x9ae757596946075f, 0x3375788de9b06958,
+      0xc1a12d2fc3978937, 0x52d6b1641c83ae,
+      0xf209787bb47d6b84, 0xc0678c5dbd23a49a,
+      0x9745eb4d50ce6332, 0xf840b7ba963646e0,
+      0xbd176620a501fbff, 0xb650e5a93bc3d898,
+      0xec5d3fa8ce427aff, 0xa3e51f138ab4cebe,
+      0x93ba47c980e98cdf, 0xc66f336c36b10137,
+      0xb8a8d9bbe123f017, 0xb80b0047445d4184,
+      0xe6d3102ad96cec1d, 0xa60dc059157491e5,
+      0x9043ea1ac7e41392, 0x87c89837ad68db2f,
+      0xb454e4a179dd1877, 0x29babe4598c311fb,
+      0xe16a1dc9d8545e94, 0xf4296dd6fef3d67a,
+      0x8ce2529e2734bb1d, 0x1899e4a65f58660c,
+      0xb01ae745b101e9e4, 0x5ec05dcff72e7f8f,
+      0xdc21a1171d42645d, 0x76707543f4fa1f73,
+      0x899504ae72497eba, 0x6a06494a791c53a8,
+      0xabfa45da0edbde69, 0x487db9d17636892,
+      0xd6f8d7509292d603, 0x45a9d2845d3c42b6,
+      0x865b86925b9bc5c2, 0xb8a2392ba45a9b2,
+      0xa7f26836f282b732, 0x8e6cac7768d7141e,
+      0xd1ef0244af2364ff, 0x3207d795430cd926,
+      0x8335616aed761f1f, 0x7f44e6bd49e807b8,
+      0xa402b9c5a8d3a6e7, 0x5f16206c9c6209a6,
+      0xcd036837130890a1, 0x36dba887c37a8c0f,
+      0x802221226be55a64, 0xc2494954da2c9789,
+      0xa02aa96b06deb0fd, 0xf2db9baa10b7bd6c,
+      0xc83553c5c8965d3d, 0x6f92829494e5acc7,
+      0xfa42a8b73abbf48c, 0xcb772339ba1f17f9,
+      0x9c69a97284b578d7, 0xff2a760414536efb,
+      0xc38413cf25e2d70d, 0xfef5138519684aba,
+      0xf46518c2ef5b8cd1, 0x7eb258665fc25d69,
+      0x98bf2f79d5993802, 0xef2f773ffbd97a61,
+      0xbeeefb584aff8603, 0xaafb550ffacfd8fa,
+      0xeeaaba2e5dbf6784, 0x95ba2a53f983cf38,
+      0x952ab45cfa97a0b2, 0xdd945a747bf26183,
+      0xba756174393d88df, 0x94f971119aeef9e4,
+      0xe912b9d1478ceb17, 0x7a37cd5601aab85d,
+      0x91abb422ccb812ee, 0xac62e055c10ab33a,
+      0xb616a12b7fe617aa, 0x577b986b314d6009,
+      0xe39c49765fdf9d94, 0xed5a7e85fda0b80b,
+      0x8e41ade9fbebc27d, 0x14588f13be847307,
+      0xb1d219647ae6b31c, 0x596eb2d8ae258fc8,
+      0xde469fbd99a05fe3, 0x6fca5f8ed9aef3bb,
+      0x8aec23d680043bee, 0x25de7bb9480d5854,
+      0xada72ccc20054ae9, 0xaf561aa79a10ae6a,
+      0xd910f7ff28069da4, 0x1b2ba1518094da04,
+      0x87aa9aff79042286, 0x90fb44d2f05d0842,
+      0xa99541bf57452b28, 0x353a1607ac744a53,
+      0xd3fa922f2d1675f2, 0x42889b8997915ce8,
+      0x847c9b5d7c2e09b7, 0x69956135febada11,
+      0xa59bc234db398c25, 0x43fab9837e699095,
+      0xcf02b2c21207ef2e, 0x94f967e45e03f4bb,
+      0x8161afb94b44f57d, 0x1d1be0eebac278f5,
+      0xa1ba1ba79e1632dc, 0x6462d92a69731732,
+      0xca28a291859bbf93, 0x7d7b8f7503cfdcfe,
+      0xfcb2cb35e702af78, 0x5cda735244c3d43e,
+      0x9defbf01b061adab, 0x3a0888136afa64a7,
+      0xc56baec21c7a1916, 0x88aaa1845b8fdd0,
+      0xf6c69a72a3989f5b, 0x8aad549e57273d45,
+      0x9a3c2087a63f6399, 0x36ac54e2f678864b,
+      0xc0cb28a98fcf3c7f, 0x84576a1bb416a7dd,
+      0xf0fdf2d3f3c30b9f, 0x656d44a2a11c51d5,
+      0x969eb7c47859e743, 0x9f644ae5a4b1b325,
+      0xbc4665b596706114, 0x873d5d9f0dde1fee,
+      0xeb57ff22fc0c7959, 0xa90cb506d155a7ea,
+      0x9316ff75dd87cbd8, 0x9a7f12442d588f2,
+      0xb7dcbf5354e9bece, 0xc11ed6d538aeb2f,
+      0xe5d3ef282a242e81, 0x8f1668c8a86da5fa,
+      0x8fa475791a569d10, 0xf96e017d694487bc,
+      0xb38d92d760ec4455, 0x37c981dcc395a9ac,
+      0xe070f78d3927556a, 0x85bbe253f47b1417,
+      0x8c469ab843b89562, 0x93956d7478ccec8e,
+      0xaf58416654a6babb, 0x387ac8d1970027b2,
+      0xdb2e51bfe9d0696a, 0x6997b05fcc0319e,
+      0x88fcf317f22241e2, 0x441fece3bdf81f03,
+      0xab3c2fddeeaad25a, 0xd527e81cad7626c3,
+      0xd60b3bd56a5586f1, 0x8a71e223d8d3b074,
+      0x85c7056562757456, 0xf6872d5667844e49,
+      0xa738c6bebb12d16c, 0xb428f8ac016561db,
+      0xd106f86e69d785c7, 0xe13336d701beba52,
+      0x82a45b450226b39c, 0xecc0024661173473,
+      0xa34d721642b06084, 0x27f002d7f95d0190,
+      0xcc20ce9bd35c78a5, 0x31ec038df7b441f4,
+      0xff290242c83396ce, 0x7e67047175a15271,
+      0x9f79a169bd203e41, 0xf0062c6e984d386,
+      0xc75809c42c684dd1, 0x52c07b78a3e60868,
+      0xf92e0c3537826145, 0xa7709a56ccdf8a82,
+      0x9bbcc7a142b17ccb, 0x88a66076400bb691,
+      0xc2abf989935ddbfe, 0x6acff893d00ea435,
+      0xf356f7ebf83552fe, 0x583f6b8c4124d43,
+      0x98165af37b2153de, 0xc3727a337a8b704a,
+      0xbe1bf1b059e9a8d6, 0x744f18c0592e4c5c,
+      0xeda2ee1c7064130c, 0x1162def06f79df73,
+      0x9485d4d1c63e8be7, 0x8addcb5645ac2ba8,
+      0xb9a74a0637ce2ee1, 0x6d953e2bd7173692,
+      0xe8111c87c5c1ba99, 0xc8fa8db6ccdd0437,
+      0x910ab1d4db9914a0, 0x1d9c9892400a22a2,
+      0xb54d5e4a127f59c8, 0x2503beb6d00cab4b,
+      0xe2a0b5dc971f303a, 0x2e44ae64840fd61d,
+      0x8da471a9de737e24, 0x5ceaecfed289e5d2,
+      0xb10d8e1456105dad, 0x7425a83e872c5f47,
+      0xdd50f1996b947518, 0xd12f124e28f77719,
+      0x8a5296ffe33cc92f, 0x82bd6b70d99aaa6f,
+      0xace73cbfdc0bfb7b, 0x636cc64d1001550b,
+      0xd8210befd30efa5a, 0x3c47f7e05401aa4e,
+      0x8714a775e3e95c78, 0x65acfaec34810a71,
+      0xa8d9d1535ce3b396, 0x7f1839a741a14d0d,
+      0xd31045a8341ca07c, 0x1ede48111209a050,
+      0x83ea2b892091e44d, 0x934aed0aab460432,
+      0xa4e4b66b68b65d60, 0xf81da84d5617853f,
+      0xce1de40642e3f4b9, 0x36251260ab9d668e,
+      0x80d2ae83e9ce78f3, 0xc1d72b7c6b426019,
+      0xa1075a24e4421730, 0xb24cf65b8612f81f,
+      0xc94930ae1d529cfc, 0xdee033f26797b627,
+      0xfb9b7cd9a4a7443c, 0x169840ef017da3b1,
+      0x9d412e0806e88aa5, 0x8e1f289560ee864e,
+      0xc491798a08a2ad4e, 0xf1a6f2bab92a27e2,
+      0xf5b5d7ec8acb58a2, 0xae10af696774b1db,
+      0x9991a6f3d6bf1765, 0xacca6da1e0a8ef29,
+      0xbff610b0cc6edd3f, 0x17fd090a58d32af3,
+      0xeff394dcff8a948e, 0xddfc4b4cef07f5b0,
+      0x95f83d0a1fb69cd9, 0x4abdaf101564f98e,
+      0xbb764c4ca7a4440f, 0x9d6d1ad41abe37f1,
+      0xea53df5fd18d5513, 0x84c86189216dc5ed,
+      0x92746b9be2f8552c, 0x32fd3cf5b4e49bb4,
+      0xb7118682dbb66a77, 0x3fbc8c33221dc2a1,
+      0xe4d5e82392a40515, 0xfabaf3feaa5334a,
+      0x8f05b1163ba6832d, 0x29cb4d87f2a7400e,
+      0xb2c71d5bca9023f8, 0x743e20e9ef511012,
+      0xdf78e4b2bd342cf6, 0x914da9246b255416,
+      0x8bab8eefb6409c1a, 0x1ad089b6c2f7548e,
+      0xae9672aba3d0c320, 0xa184ac2473b529b1,
+      0xda3c0f568cc4f3e8, 0xc9e5d72d90a2741e,
+      0x8865899617fb1871, 0x7e2fa67c7a658892,
+      0xaa7eebfb9df9de8d, 0xddbb901b98feeab7,
+      0xd51ea6fa85785631, 0x552a74227f3ea565,
+      0x8533285c936b35de, 0xd53a88958f87275f,
+      0xa67ff273b8460356, 0x8a892abaf368f137,
+      0xd01fef10a657842c, 0x2d2b7569b0432d85,
+      0x8213f56a67f6b29b, 0x9c3b29620e29fc73,
+      0xa298f2c501f45f42, 0x8349f3ba91b47b8f,
+      0xcb3f2f7642717713, 0x241c70a936219a73,
+      0xfe0efb53d30dd4d7, 0xed238cd383aa0110,
+      0x9ec95d1463e8a506, 0xf4363804324a40aa,
+      0xc67bb4597ce2ce48, 0xb143c6053edcd0d5,
+      0xf81aa16fdc1b81da, 0xdd94b7868e94050a,
+      0x9b10a4e5e9913128, 0xca7cf2b4191c8326,
+      0xc1d4ce1f63f57d72, 0xfd1c2f611f63a3f0,
+      0xf24a01a73cf2dccf, 0xbc633b39673c8cec,
+      0x976e41088617ca01, 0xd5be0503e085d813,
+      0xbd49d14aa79dbc82, 0x4b2d8644d8a74e18,
+      0xec9c459d51852ba2, 0xddf8e7d60ed1219e,
+      0x93e1ab8252f33b45, 0xcabb90e5c942b503,
+      0xb8da1662e7b00a17, 0x3d6a751f3b936243,
+      0xe7109bfba19c0c9d, 0xcc512670a783ad4,
+      0x906a617d450187e2, 0x27fb2b80668b24c5,
+      0xb484f9dc9641e9da, 0xb1f9f660802dedf6,
+      0xe1a63853bbd26451, 0x5e7873f8a0396973,
+      0x8d07e33455637eb2, 0xdb0b487b6423e1e8,
+      0xb049dc016abc5e5f, 0x91ce1a9a3d2cda62,
+      0xdc5c5301c56b75f7, 0x7641a140cc7810fb,
+      0x89b9b3e11b6329ba, 0xa9e904c87fcb0a9d,
+      0xac2820d9623bf429, 0x546345fa9fbdcd44,
+      0xd732290fbacaf133, 0xa97c177947ad4095,
+      0x867f59a9d4bed6c0, 0x49ed8eabcccc485d,
+      0xa81f301449ee8c70, 0x5c68f256bfff5a74,
+      0xd226fc195c6a2f8c, 0x73832eec6fff3111,
+      0x83585d8fd9c25db7, 0xc831fd53c5ff7eab,
+      0xa42e74f3d032f525, 0xba3e7ca8b77f5e55,
+      0xcd3a1230c43fb26f, 0x28ce1bd2e55f35eb,
+      0x80444b5e7aa7cf85, 0x7980d163cf5b81b3,
+      0xa0555e361951c366, 0xd7e105bcc332621f,
+      0xc86ab5c39fa63440, 0x8dd9472bf3fefaa7,
+      0xfa856334878fc150, 0xb14f98f6f0feb951,
+      0x9c935e00d4b9d8d2, 0x6ed1bf9a569f33d3,
+      0xc3b8358109e84f07, 0xa862f80ec4700c8,
+      0xf4a642e14c6262c8, 0xcd27bb612758c0fa,
+      0x98e7e9cccfbd7dbd, 0x8038d51cb897789c,
+      0xbf21e44003acdd2c, 0xe0470a63e6bd56c3,
+      0xeeea5d5004981478, 0x1858ccfce06cac74,
+      0x95527a5202df0ccb, 0xf37801e0c43ebc8,
+      0xbaa718e68396cffd, 0xd30560258f54e6ba,
+      0xe950df20247c83fd, 0x47c6b82ef32a2069,
+      0x91d28b7416cdd27e, 0x4cdc331d57fa5441,
+      0xb6472e511c81471d, 0xe0133fe4adf8e952,
+      0xe3d8f9e563a198e5, 0x58180fddd97723a6,
+      0x8e679c2f5e44ff8f, 0x570f09eaa7ea7648,
+  };
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <class unused>
+constexpr uint64_t
+    powers_template<unused>::power_of_five_128[number_of_entries];
+
+#endif
+
+using powers = powers_template<>;
+
+} // namespace fast_float
+
+#endif
+
+#ifndef FASTFLOAT_DECIMAL_TO_BINARY_H
+#define FASTFLOAT_DECIMAL_TO_BINARY_H
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+
+namespace fast_float {
+
+// This will compute or rather approximate w * 5**q and return a pair of 64-bit
+// words approximating the result, with the "high" part corresponding to the
+// most significant bits and the low part corresponding to the least significant
+// bits.
+//
+template <int bit_precision>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 value128
+compute_product_approximation(int64_t q, uint64_t w) {
+  int const index = 2 * int(q - powers::smallest_power_of_five);
+  // For small values of q, e.g., q in [0,27], the answer is always exact
+  // because The line value128 firstproduct = full_multiplication(w,
+  // power_of_five_128[index]); gives the exact answer.
+  value128 firstproduct =
+      full_multiplication(w, powers::power_of_five_128[index]);
+  static_assert((bit_precision >= 0) && (bit_precision <= 64),
+                " precision should  be in (0,64]");
+  constexpr uint64_t precision_mask =
+      (bit_precision < 64) ? (uint64_t(0xFFFFFFFFFFFFFFFF) >> bit_precision)
+                           : uint64_t(0xFFFFFFFFFFFFFFFF);
+  if ((firstproduct.high & precision_mask) ==
+      precision_mask) { // could further guard with  (lower + w < lower)
+    // regarding the second product, we only need secondproduct.high, but our
+    // expectation is that the compiler will optimize this extra work away if
+    // needed.
+    value128 secondproduct =
+        full_multiplication(w, powers::power_of_five_128[index + 1]);
+    firstproduct.low += secondproduct.high;
+    if (secondproduct.high > firstproduct.low) {
+      firstproduct.high++;
+    }
+  }
+  return firstproduct;
+}
+
+namespace detail {
+/**
+ * For q in (0,350), we have that
+ *  f = (((152170 + 65536) * q ) >> 16);
+ * is equal to
+ *   floor(p) + q
+ * where
+ *   p = log(5**q)/log(2) = q * log(5)/log(2)
+ *
+ * For negative values of q in (-400,0), we have that
+ *  f = (((152170 + 65536) * q ) >> 16);
+ * is equal to
+ *   -ceil(p) + q
+ * where
+ *   p = log(5**-q)/log(2) = -q * log(5)/log(2)
+ */
+constexpr fastfloat_really_inline int32_t power(int32_t q) noexcept {
+  return (((152170 + 65536) * q) >> 16) + 63;
+}
+} // namespace detail
+
+// create an adjusted mantissa, biased by the invalid power2
+// for significant digits already multiplied by 10 ** q.
+template <typename binary>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 adjusted_mantissa
+compute_error_scaled(int64_t q, uint64_t w, int lz) noexcept {
+  int hilz = int(w >> 63) ^ 1;
+  adjusted_mantissa answer;
+  answer.mantissa = w << hilz;
+  int bias = binary::mantissa_explicit_bits() - binary::minimum_exponent();
+  answer.power2 = int32_t(detail::power(int32_t(q)) + bias - hilz - lz - 62 +
+                          invalid_am_bias);
+  return answer;
+}
+
+// w * 10 ** q, without rounding the representation up.
+// the power2 in the exponent will be adjusted by invalid_am_bias.
+template <typename binary>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 adjusted_mantissa
+compute_error(int64_t q, uint64_t w) noexcept {
+  int lz = leading_zeroes(w);
+  w <<= lz;
+  value128 product =
+      compute_product_approximation<binary::mantissa_explicit_bits() + 3>(q, w);
+  return compute_error_scaled<binary>(q, product.high, lz);
+}
+
+// Computers w * 10 ** q.
+// The returned value should be a valid number that simply needs to be
+// packed. However, in some very rare cases, the computation will fail. In such
+// cases, we return an adjusted_mantissa with a negative power of 2: the caller
+// should recompute in such cases.
+template <typename binary>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 adjusted_mantissa
+compute_float(int64_t q, uint64_t w) noexcept {
+  adjusted_mantissa answer;
+  if ((w == 0) || (q < binary::smallest_power_of_ten())) {
+    answer.power2 = 0;
+    answer.mantissa = 0;
+    // result should be zero
+    return answer;
+  }
+  if (q > binary::largest_power_of_ten()) {
+    // we want to get infinity:
+    answer.power2 = binary::infinite_power();
+    answer.mantissa = 0;
+    return answer;
+  }
+  // At this point in time q is in [powers::smallest_power_of_five,
+  // powers::largest_power_of_five].
+
+  // We want the most significant bit of i to be 1. Shift if needed.
+  int lz = leading_zeroes(w);
+  w <<= lz;
+
+  // The required precision is binary::mantissa_explicit_bits() + 3 because
+  // 1. We need the implicit bit
+  // 2. We need an extra bit for rounding purposes
+  // 3. We might lose a bit due to the "upperbit" routine (result too small,
+  // requiring a shift)
+
+  value128 product =
+      compute_product_approximation<binary::mantissa_explicit_bits() + 3>(q, w);
+  // The computed 'product' is always sufficient.
+  // Mathematical proof:
+  // Noble Mushtak and Daniel Lemire, Fast Number Parsing Without Fallback (to
+  // appear) See script/mushtak_lemire.py
+
+  // The "compute_product_approximation" function can be slightly slower than a
+  // branchless approach: value128 product = compute_product(q, w); but in
+  // practice, we can win big with the compute_product_approximation if its
+  // additional branch is easily predicted. Which is best is data specific.
+  int upperbit = int(product.high >> 63);
+  int shift = upperbit + 64 - binary::mantissa_explicit_bits() - 3;
+
+  answer.mantissa = product.high >> shift;
+
+  answer.power2 = int32_t(detail::power(int32_t(q)) + upperbit - lz -
+                          binary::minimum_exponent());
+  if (answer.power2 <= 0) { // we have a subnormal?
+    // Here have that answer.power2 <= 0 so -answer.power2 >= 0
+    if (-answer.power2 + 1 >=
+        64) { // if we have more than 64 bits below the minimum exponent, you
+              // have a zero for sure.
+      answer.power2 = 0;
+      answer.mantissa = 0;
+      // result should be zero
+      return answer;
+    }
+    // next line is safe because -answer.power2 + 1 < 64
+    answer.mantissa >>= -answer.power2 + 1;
+    // Thankfully, we can't have both "round-to-even" and subnormals because
+    // "round-to-even" only occurs for powers close to 0 in the 32-bit and
+    // and 64-bit case (with no more than 19 digits).
+    answer.mantissa += (answer.mantissa & 1); // round up
+    answer.mantissa >>= 1;
+    // There is a weird scenario where we don't have a subnormal but just.
+    // Suppose we start with 2.2250738585072013e-308, we end up
+    // with 0x3fffffffffffff x 2^-1023-53 which is technically subnormal
+    // whereas 0x40000000000000 x 2^-1023-53  is normal. Now, we need to round
+    // up 0x3fffffffffffff x 2^-1023-53  and once we do, we are no longer
+    // subnormal, but we can only know this after rounding.
+    // So we only declare a subnormal if we are smaller than the threshold.
+    answer.power2 =
+        (answer.mantissa < (uint64_t(1) << binary::mantissa_explicit_bits()))
+            ? 0
+            : 1;
+    return answer;
+  }
+
+  // usually, we round *up*, but if we fall right in between and and we have an
+  // even basis, we need to round down
+  // We are only concerned with the cases where 5**q fits in single 64-bit word.
+  if ((product.low <= 1) && (q >= binary::min_exponent_round_to_even()) &&
+      (q <= binary::max_exponent_round_to_even()) &&
+      ((answer.mantissa & 3) == 1)) { // we may fall between two floats!
+    // To be in-between two floats we need that in doing
+    //   answer.mantissa = product.high >> (upperbit + 64 -
+    //   binary::mantissa_explicit_bits() - 3);
+    // ... we dropped out only zeroes. But if this happened, then we can go
+    // back!!!
+    if ((answer.mantissa << shift) == product.high) {
+      answer.mantissa &= ~uint64_t(1); // flip it so that we do not round up
+    }
+  }
+
+  answer.mantissa += (answer.mantissa & 1); // round up
+  answer.mantissa >>= 1;
+  if (answer.mantissa >= (uint64_t(2) << binary::mantissa_explicit_bits())) {
+    answer.mantissa = (uint64_t(1) << binary::mantissa_explicit_bits());
+    answer.power2++; // undo previous addition
+  }
+
+  answer.mantissa &= ~(uint64_t(1) << binary::mantissa_explicit_bits());
+  if (answer.power2 >= binary::infinite_power()) { // infinity
+    answer.power2 = binary::infinite_power();
+    answer.mantissa = 0;
+  }
+  return answer;
+}
+
+} // namespace fast_float
+
+#endif
+
+#ifndef FASTFLOAT_BIGINT_H
+#define FASTFLOAT_BIGINT_H
+
+#include <cstring>
+
+
+namespace fast_float {
+
+// the limb width: we want efficient multiplication of double the bits in
+// limb, or for 64-bit limbs, at least 64-bit multiplication where we can
+// extract the high and low parts efficiently. this is every 64-bit
+// architecture except for sparc, which emulates 128-bit multiplication.
+// we might have platforms where `CHAR_BIT` is not 8, so let's avoid
+// doing `8 * sizeof(limb)`.
+#if defined(FASTFLOAT_64BIT) && !defined(__sparc)
+#define FASTFLOAT_64BIT_LIMB 1
+typedef uint64_t limb;
+constexpr size_t limb_bits = 64;
+#else
+#define FASTFLOAT_32BIT_LIMB
+typedef uint32_t limb;
+constexpr size_t limb_bits = 32;
+#endif
+
+typedef span<limb> limb_span;
+
+// number of bits in a bigint. this needs to be at least the number
+// of bits required to store the largest bigint, which is
+// `log2(10**(digits + max_exp))`, or `log2(10**(767 + 342))`, or
+// ~3600 bits, so we round to 4000.
+constexpr size_t bigint_bits = 4000;
+constexpr size_t bigint_limbs = bigint_bits / limb_bits;
+
+// vector-like type that is allocated on the stack. the entire
+// buffer is pre-allocated, and only the length changes.
+template <uint16_t size> struct stackvec {
+  limb data[size];
+  // we never need more than 150 limbs
+  uint16_t length{0};
+
+  stackvec() = default;
+  stackvec(stackvec const &) = delete;
+  stackvec &operator=(stackvec const &) = delete;
+  stackvec(stackvec &&) = delete;
+  stackvec &operator=(stackvec &&other) = delete;
+
+  // create stack vector from existing limb span.
+  FASTFLOAT_CONSTEXPR20 stackvec(limb_span s) {
+    FASTFLOAT_ASSERT(try_extend(s));
+  }
+
+  FASTFLOAT_CONSTEXPR14 limb &operator[](size_t index) noexcept {
+    FASTFLOAT_DEBUG_ASSERT(index < length);
+    return data[index];
+  }
+
+  FASTFLOAT_CONSTEXPR14 const limb &operator[](size_t index) const noexcept {
+    FASTFLOAT_DEBUG_ASSERT(index < length);
+    return data[index];
+  }
+
+  // index from the end of the container
+  FASTFLOAT_CONSTEXPR14 const limb &rindex(size_t index) const noexcept {
+    FASTFLOAT_DEBUG_ASSERT(index < length);
+    size_t rindex = length - index - 1;
+    return data[rindex];
+  }
+
+  // set the length, without bounds checking.
+  FASTFLOAT_CONSTEXPR14 void set_len(size_t len) noexcept {
+    length = uint16_t(len);
+  }
+
+  constexpr size_t len() const noexcept { return length; }
+
+  constexpr bool is_empty() const noexcept { return length == 0; }
+
+  constexpr size_t capacity() const noexcept { return size; }
+
+  // append item to vector, without bounds checking
+  FASTFLOAT_CONSTEXPR14 void push_unchecked(limb value) noexcept {
+    data[length] = value;
+    length++;
+  }
+
+  // append item to vector, returning if item was added
+  FASTFLOAT_CONSTEXPR14 bool try_push(limb value) noexcept {
+    if (len() < capacity()) {
+      push_unchecked(value);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // add items to the vector, from a span, without bounds checking
+  FASTFLOAT_CONSTEXPR20 void extend_unchecked(limb_span s) noexcept {
+    limb *ptr = data + length;
+    tinyobj_ff::copy_n(s.ptr, s.len(), ptr);
+    set_len(len() + s.len());
+  }
+
+  // try to add items to the vector, returning if items were added
+  FASTFLOAT_CONSTEXPR20 bool try_extend(limb_span s) noexcept {
+    if (len() + s.len() <= capacity()) {
+      extend_unchecked(s);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // resize the vector, without bounds checking
+  // if the new size is longer than the vector, assign value to each
+  // appended item.
+  FASTFLOAT_CONSTEXPR20
+  void resize_unchecked(size_t new_len, limb value) noexcept {
+    if (new_len > len()) {
+      size_t count = new_len - len();
+      limb *first = data + len();
+      limb *last = first + count;
+      tinyobj_ff::fill(first, last, value);
+      set_len(new_len);
+    } else {
+      set_len(new_len);
+    }
+  }
+
+  // try to resize the vector, returning if the vector was resized.
+  FASTFLOAT_CONSTEXPR20 bool try_resize(size_t new_len, limb value) noexcept {
+    if (new_len > capacity()) {
+      return false;
+    } else {
+      resize_unchecked(new_len, value);
+      return true;
+    }
+  }
+
+  // check if any limbs are non-zero after the given index.
+  // this needs to be done in reverse order, since the index
+  // is relative to the most significant limbs.
+  FASTFLOAT_CONSTEXPR14 bool nonzero(size_t index) const noexcept {
+    while (index < len()) {
+      if (rindex(index) != 0) {
+        return true;
+      }
+      index++;
+    }
+    return false;
+  }
+
+  // normalize the big integer, so most-significant zero limbs are removed.
+  FASTFLOAT_CONSTEXPR14 void normalize() noexcept {
+    while (len() > 0 && rindex(0) == 0) {
+      length--;
+    }
+  }
+};
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 uint64_t
+empty_hi64(bool &truncated) noexcept {
+  truncated = false;
+  return 0;
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 uint64_t
+uint64_hi64(uint64_t r0, bool &truncated) noexcept {
+  truncated = false;
+  int shl = leading_zeroes(r0);
+  return r0 << shl;
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 uint64_t
+uint64_hi64(uint64_t r0, uint64_t r1, bool &truncated) noexcept {
+  int shl = leading_zeroes(r0);
+  if (shl == 0) {
+    truncated = r1 != 0;
+    return r0;
+  } else {
+    int shr = 64 - shl;
+    truncated = (r1 << shl) != 0;
+    return (r0 << shl) | (r1 >> shr);
+  }
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 uint64_t
+uint32_hi64(uint32_t r0, bool &truncated) noexcept {
+  return uint64_hi64(r0, truncated);
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 uint64_t
+uint32_hi64(uint32_t r0, uint32_t r1, bool &truncated) noexcept {
+  uint64_t x0 = r0;
+  uint64_t x1 = r1;
+  return uint64_hi64((x0 << 32) | x1, truncated);
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 uint64_t
+uint32_hi64(uint32_t r0, uint32_t r1, uint32_t r2, bool &truncated) noexcept {
+  uint64_t x0 = r0;
+  uint64_t x1 = r1;
+  uint64_t x2 = r2;
+  return uint64_hi64(x0, (x1 << 32) | x2, truncated);
+}
+
+// add two small integers, checking for overflow.
+// we want an efficient operation. for msvc, where
+// we don't have built-in intrinsics, this is still
+// pretty fast.
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 limb
+scalar_add(limb x, limb y, bool &overflow) noexcept {
+  limb z;
+// gcc and clang
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_add_overflow)
+  if (!cpp20_and_in_constexpr()) {
+    overflow = __builtin_add_overflow(x, y, &z);
+    return z;
+  }
+#endif
+#endif
+
+  // generic, this still optimizes correctly on MSVC.
+  z = x + y;
+  overflow = z < x;
+  return z;
+}
+
+// multiply two small integers, getting both the high and low bits.
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 limb
+scalar_mul(limb x, limb y, limb &carry) noexcept {
+#ifdef FASTFLOAT_64BIT_LIMB
+#if defined(__SIZEOF_INT128__)
+  // GCC and clang both define it as an extension.
+  __uint128_t z = __uint128_t(x) * __uint128_t(y) + __uint128_t(carry);
+  carry = limb(z >> limb_bits);
+  return limb(z);
+#else
+  // fallback, no native 128-bit integer multiplication with carry.
+  // on msvc, this optimizes identically, somehow.
+  value128 z = full_multiplication(x, y);
+  bool overflow;
+  z.low = scalar_add(z.low, carry, overflow);
+  z.high += uint64_t(overflow); // cannot overflow
+  carry = z.high;
+  return z.low;
+#endif
+#else
+  uint64_t z = uint64_t(x) * uint64_t(y) + uint64_t(carry);
+  carry = limb(z >> limb_bits);
+  return limb(z);
+#endif
+}
+
+// add scalar value to bigint starting from offset.
+// used in grade school multiplication
+template <uint16_t size>
+inline FASTFLOAT_CONSTEXPR20 bool small_add_from(stackvec<size> &vec, limb y,
+                                                 size_t start) noexcept {
+  size_t index = start;
+  limb carry = y;
+  bool overflow;
+  while (carry != 0 && index < vec.len()) {
+    vec[index] = scalar_add(vec[index], carry, overflow);
+    carry = limb(overflow);
+    index += 1;
+  }
+  if (carry != 0) {
+    FASTFLOAT_TRY(vec.try_push(carry));
+  }
+  return true;
+}
+
+// add scalar value to bigint.
+template <uint16_t size>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 bool
+small_add(stackvec<size> &vec, limb y) noexcept {
+  return small_add_from(vec, y, 0);
+}
+
+// multiply bigint by scalar value.
+template <uint16_t size>
+inline FASTFLOAT_CONSTEXPR20 bool small_mul(stackvec<size> &vec,
+                                            limb y) noexcept {
+  limb carry = 0;
+  for (size_t index = 0; index < vec.len(); index++) {
+    vec[index] = scalar_mul(vec[index], y, carry);
+  }
+  if (carry != 0) {
+    FASTFLOAT_TRY(vec.try_push(carry));
+  }
+  return true;
+}
+
+// add bigint to bigint starting from index.
+// used in grade school multiplication
+template <uint16_t size>
+FASTFLOAT_CONSTEXPR20 bool large_add_from(stackvec<size> &x, limb_span y,
+                                          size_t start) noexcept {
+  // the effective x buffer is from `xstart..x.len()`, so exit early
+  // if we can't get that current range.
+  if (x.len() < start || y.len() > x.len() - start) {
+    FASTFLOAT_TRY(x.try_resize(y.len() + start, 0));
+  }
+
+  bool carry = false;
+  for (size_t index = 0; index < y.len(); index++) {
+    limb xi = x[index + start];
+    limb yi = y[index];
+    bool c1 = false;
+    bool c2 = false;
+    xi = scalar_add(xi, yi, c1);
+    if (carry) {
+      xi = scalar_add(xi, 1, c2);
+    }
+    x[index + start] = xi;
+    carry = c1 | c2;
+  }
+
+  // handle overflow
+  if (carry) {
+    FASTFLOAT_TRY(small_add_from(x, 1, y.len() + start));
+  }
+  return true;
+}
+
+// add bigint to bigint.
+template <uint16_t size>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 bool
+large_add_from(stackvec<size> &x, limb_span y) noexcept {
+  return large_add_from(x, y, 0);
+}
+
+// grade-school multiplication algorithm
+template <uint16_t size>
+FASTFLOAT_CONSTEXPR20 bool long_mul(stackvec<size> &x, limb_span y) noexcept {
+  limb_span xs = limb_span(x.data, x.len());
+  stackvec<size> z(xs);
+  limb_span zs = limb_span(z.data, z.len());
+
+  if (y.len() != 0) {
+    limb y0 = y[0];
+    FASTFLOAT_TRY(small_mul(x, y0));
+    for (size_t index = 1; index < y.len(); index++) {
+      limb yi = y[index];
+      stackvec<size> zi;
+      if (yi != 0) {
+        // re-use the same buffer throughout
+        zi.set_len(0);
+        FASTFLOAT_TRY(zi.try_extend(zs));
+        FASTFLOAT_TRY(small_mul(zi, yi));
+        limb_span zis = limb_span(zi.data, zi.len());
+        FASTFLOAT_TRY(large_add_from(x, zis, index));
+      }
+    }
+  }
+
+  x.normalize();
+  return true;
+}
+
+// grade-school multiplication algorithm
+template <uint16_t size>
+FASTFLOAT_CONSTEXPR20 bool large_mul(stackvec<size> &x, limb_span y) noexcept {
+  if (y.len() == 1) {
+    FASTFLOAT_TRY(small_mul(x, y[0]));
+  } else {
+    FASTFLOAT_TRY(long_mul(x, y));
+  }
+  return true;
+}
+
+template <typename = void> struct pow5_tables {
+  static constexpr uint32_t large_step = 135;
+  static constexpr uint64_t small_power_of_5[] = {
+      1UL,
+      5UL,
+      25UL,
+      125UL,
+      625UL,
+      3125UL,
+      15625UL,
+      78125UL,
+      390625UL,
+      1953125UL,
+      9765625UL,
+      48828125UL,
+      244140625UL,
+      1220703125UL,
+      6103515625UL,
+      30517578125UL,
+      152587890625UL,
+      762939453125UL,
+      3814697265625UL,
+      19073486328125UL,
+      95367431640625UL,
+      476837158203125UL,
+      2384185791015625UL,
+      11920928955078125UL,
+      59604644775390625UL,
+      298023223876953125UL,
+      1490116119384765625UL,
+      7450580596923828125UL,
+  };
+#ifdef FASTFLOAT_64BIT_LIMB
+  constexpr static limb large_power_of_5[] = {
+      1414648277510068013UL, 9180637584431281687UL, 4539964771860779200UL,
+      10482974169319127550UL, 198276706040285095UL};
+#else
+  constexpr static limb large_power_of_5[] = {
+      4279965485U, 329373468U,  4020270615U, 2137533757U, 4287402176U,
+      1057042919U, 1071430142U, 2440757623U, 381945767U,  46164893U};
+#endif
+};
+
+#if FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+
+template <typename T> constexpr uint32_t pow5_tables<T>::large_step;
+
+template <typename T> constexpr uint64_t pow5_tables<T>::small_power_of_5[];
+
+template <typename T> constexpr limb pow5_tables<T>::large_power_of_5[];
+
+#endif
+
+// big integer type. implements a small subset of big integer
+// arithmetic, using simple algorithms since asymptotically
+// faster algorithms are slower for a small number of limbs.
+// all operations assume the big-integer is normalized.
+struct bigint : pow5_tables<> {
+  // storage of the limbs, in little-endian order.
+  stackvec<bigint_limbs> vec;
+
+  FASTFLOAT_CONSTEXPR20 bigint() : vec() {}
+
+  bigint(bigint const &) = delete;
+  bigint &operator=(bigint const &) = delete;
+  bigint(bigint &&) = delete;
+  bigint &operator=(bigint &&other) = delete;
+
+  FASTFLOAT_CONSTEXPR20 bigint(uint64_t value) : vec() {
+#ifdef FASTFLOAT_64BIT_LIMB
+    vec.push_unchecked(value);
+#else
+    vec.push_unchecked(uint32_t(value));
+    vec.push_unchecked(uint32_t(value >> 32));
+#endif
+    vec.normalize();
+  }
+
+  // get the high 64 bits from the vector, and if bits were truncated.
+  // this is to get the significant digits for the float.
+  FASTFLOAT_CONSTEXPR20 uint64_t hi64(bool &truncated) const noexcept {
+#ifdef FASTFLOAT_64BIT_LIMB
+    if (vec.len() == 0) {
+      return empty_hi64(truncated);
+    } else if (vec.len() == 1) {
+      return uint64_hi64(vec.rindex(0), truncated);
+    } else {
+      uint64_t result = uint64_hi64(vec.rindex(0), vec.rindex(1), truncated);
+      truncated |= vec.nonzero(2);
+      return result;
+    }
+#else
+    if (vec.len() == 0) {
+      return empty_hi64(truncated);
+    } else if (vec.len() == 1) {
+      return uint32_hi64(vec.rindex(0), truncated);
+    } else if (vec.len() == 2) {
+      return uint32_hi64(vec.rindex(0), vec.rindex(1), truncated);
+    } else {
+      uint64_t result =
+          uint32_hi64(vec.rindex(0), vec.rindex(1), vec.rindex(2), truncated);
+      truncated |= vec.nonzero(3);
+      return result;
+    }
+#endif
+  }
+
+  // compare two big integers, returning the large value.
+  // assumes both are normalized. if the return value is
+  // negative, other is larger, if the return value is
+  // positive, this is larger, otherwise they are equal.
+  // the limbs are stored in little-endian order, so we
+  // must compare the limbs in ever order.
+  FASTFLOAT_CONSTEXPR20 int compare(bigint const &other) const noexcept {
+    if (vec.len() > other.vec.len()) {
+      return 1;
+    } else if (vec.len() < other.vec.len()) {
+      return -1;
+    } else {
+      for (size_t index = vec.len(); index > 0; index--) {
+        limb xi = vec[index - 1];
+        limb yi = other.vec[index - 1];
+        if (xi > yi) {
+          return 1;
+        } else if (xi < yi) {
+          return -1;
+        }
+      }
+      return 0;
+    }
+  }
+
+  // shift left each limb n bits, carrying over to the new limb
+  // returns true if we were able to shift all the digits.
+  FASTFLOAT_CONSTEXPR20 bool shl_bits(size_t n) noexcept {
+    // Internally, for each item, we shift left by n, and add the previous
+    // right shifted limb-bits.
+    // For example, we transform (for u8) shifted left 2, to:
+    //      b10100100 b01000010
+    //      b10 b10010001 b00001000
+    FASTFLOAT_DEBUG_ASSERT(n != 0);
+    FASTFLOAT_DEBUG_ASSERT(n < sizeof(limb) * 8);
+
+    size_t shl = n;
+    size_t shr = limb_bits - shl;
+    limb prev = 0;
+    for (size_t index = 0; index < vec.len(); index++) {
+      limb xi = vec[index];
+      vec[index] = (xi << shl) | (prev >> shr);
+      prev = xi;
+    }
+
+    limb carry = prev >> shr;
+    if (carry != 0) {
+      return vec.try_push(carry);
+    }
+    return true;
+  }
+
+  // move the limbs left by `n` limbs.
+  FASTFLOAT_CONSTEXPR20 bool shl_limbs(size_t n) noexcept {
+    FASTFLOAT_DEBUG_ASSERT(n != 0);
+    if (n + vec.len() > vec.capacity()) {
+      return false;
+    } else if (!vec.is_empty()) {
+      // move limbs
+      limb *dst = vec.data + n;
+      limb const *src = vec.data;
+      tinyobj_ff::copy_backward(src, src + vec.len(), dst + vec.len());
+      // fill in empty limbs
+      limb *first = vec.data;
+      limb *last = first + n;
+      tinyobj_ff::fill(first, last, 0);
+      vec.set_len(n + vec.len());
+      return true;
+    } else {
+      return true;
+    }
+  }
+
+  // move the limbs left by `n` bits.
+  FASTFLOAT_CONSTEXPR20 bool shl(size_t n) noexcept {
+    size_t rem = n % limb_bits;
+    size_t div = n / limb_bits;
+    if (rem != 0) {
+      FASTFLOAT_TRY(shl_bits(rem));
+    }
+    if (div != 0) {
+      FASTFLOAT_TRY(shl_limbs(div));
+    }
+    return true;
+  }
+
+  // get the number of leading zeros in the bigint.
+  FASTFLOAT_CONSTEXPR20 int ctlz() const noexcept {
+    if (vec.is_empty()) {
+      return 0;
+    } else {
+#ifdef FASTFLOAT_64BIT_LIMB
+      return leading_zeroes(vec.rindex(0));
+#else
+      // no use defining a specialized leading_zeroes for a 32-bit type.
+      uint64_t r0 = vec.rindex(0);
+      return leading_zeroes(r0 << 32);
+#endif
+    }
+  }
+
+  // get the number of bits in the bigint.
+  FASTFLOAT_CONSTEXPR20 int bit_length() const noexcept {
+    int lz = ctlz();
+    return int(limb_bits * vec.len()) - lz;
+  }
+
+  FASTFLOAT_CONSTEXPR20 bool mul(limb y) noexcept { return small_mul(vec, y); }
+
+  FASTFLOAT_CONSTEXPR20 bool add(limb y) noexcept { return small_add(vec, y); }
+
+  // multiply as if by 2 raised to a power.
+  FASTFLOAT_CONSTEXPR20 bool pow2(uint32_t exp) noexcept { return shl(exp); }
+
+  // multiply as if by 5 raised to a power.
+  FASTFLOAT_CONSTEXPR20 bool pow5(uint32_t exp) noexcept {
+    // multiply by a power of 5
+    size_t large_length = sizeof(large_power_of_5) / sizeof(limb);
+    limb_span large = limb_span(large_power_of_5, large_length);
+    while (exp >= large_step) {
+      FASTFLOAT_TRY(large_mul(vec, large));
+      exp -= large_step;
+    }
+#ifdef FASTFLOAT_64BIT_LIMB
+    uint32_t small_step = 27;
+    limb max_native = 7450580596923828125UL;
+#else
+    uint32_t small_step = 13;
+    limb max_native = 1220703125U;
+#endif
+    while (exp >= small_step) {
+      FASTFLOAT_TRY(small_mul(vec, max_native));
+      exp -= small_step;
+    }
+    if (exp != 0) {
+      // Work around clang bug https://godbolt.org/z/zedh7rrhc
+      // This is similar to https://github.com/llvm/llvm-project/issues/47746,
+      // except the workaround described there don't work here
+      FASTFLOAT_TRY(small_mul(
+          vec, limb(((void)small_power_of_5[0], small_power_of_5[exp]))));
+    }
+
+    return true;
+  }
+
+  // multiply as if by 10 raised to a power.
+  FASTFLOAT_CONSTEXPR20 bool pow10(uint32_t exp) noexcept {
+    FASTFLOAT_TRY(pow5(exp));
+    return pow2(exp);
+  }
+};
+
+} // namespace fast_float
+
+#endif
+
+#ifndef FASTFLOAT_DIGIT_COMPARISON_H
+#define FASTFLOAT_DIGIT_COMPARISON_H
+
+#include <cstring>
+
+
+namespace fast_float {
+
+// 1e0 to 1e19
+constexpr static uint64_t powers_of_ten_uint64[] = {1UL,
+                                                    10UL,
+                                                    100UL,
+                                                    1000UL,
+                                                    10000UL,
+                                                    100000UL,
+                                                    1000000UL,
+                                                    10000000UL,
+                                                    100000000UL,
+                                                    1000000000UL,
+                                                    10000000000UL,
+                                                    100000000000UL,
+                                                    1000000000000UL,
+                                                    10000000000000UL,
+                                                    100000000000000UL,
+                                                    1000000000000000UL,
+                                                    10000000000000000UL,
+                                                    100000000000000000UL,
+                                                    1000000000000000000UL,
+                                                    10000000000000000000UL};
+
+// calculate the exponent, in scientific notation, of the number.
+// this algorithm is not even close to optimized, but it has no practical
+// effect on performance: in order to have a faster algorithm, we'd need
+// to slow down performance for faster algorithms, and this is still fast.
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 int32_t
+scientific_exponent(parsed_number_string_t<UC> &num) noexcept {
+  uint64_t mantissa = num.mantissa;
+  int32_t exponent = int32_t(num.exponent);
+  while (mantissa >= 10000) {
+    mantissa /= 10000;
+    exponent += 4;
+  }
+  while (mantissa >= 100) {
+    mantissa /= 100;
+    exponent += 2;
+  }
+  while (mantissa >= 10) {
+    mantissa /= 10;
+    exponent += 1;
+  }
+  return exponent;
+}
+
+// this converts a native floating-point number to an extended-precision float.
+template <typename T>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 adjusted_mantissa
+to_extended(T value) noexcept {
+  using equiv_uint = equiv_uint_t<T>;
+  constexpr equiv_uint exponent_mask = binary_format<T>::exponent_mask();
+  constexpr equiv_uint mantissa_mask = binary_format<T>::mantissa_mask();
+  constexpr equiv_uint hidden_bit_mask = binary_format<T>::hidden_bit_mask();
+
+  adjusted_mantissa am;
+  int32_t bias = binary_format<T>::mantissa_explicit_bits() -
+                 binary_format<T>::minimum_exponent();
+  equiv_uint bits;
+#if FASTFLOAT_HAS_BIT_CAST
+  bits = std::bit_cast<equiv_uint>(value);
+#else
+  ::memcpy(&bits, &value, sizeof(T));
+#endif
+  if ((bits & exponent_mask) == 0) {
+    // denormal
+    am.power2 = 1 - bias;
+    am.mantissa = bits & mantissa_mask;
+  } else {
+    // normal
+    am.power2 = int32_t((bits & exponent_mask) >>
+                        binary_format<T>::mantissa_explicit_bits());
+    am.power2 -= bias;
+    am.mantissa = (bits & mantissa_mask) | hidden_bit_mask;
+  }
+
+  return am;
+}
+
+// get the extended precision value of the halfway point between b and b+u.
+// we are given a native float that represents b, so we need to adjust it
+// halfway between b and b+u.
+template <typename T>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 adjusted_mantissa
+to_extended_halfway(T value) noexcept {
+  adjusted_mantissa am = to_extended(value);
+  am.mantissa <<= 1;
+  am.mantissa += 1;
+  am.power2 -= 1;
+  return am;
+}
+
+// round an extended-precision float to the nearest machine float.
+template <typename T, typename callback>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 void round(adjusted_mantissa &am,
+                                                         callback cb) noexcept {
+  int32_t mantissa_shift = 64 - binary_format<T>::mantissa_explicit_bits() - 1;
+  if (-am.power2 >= mantissa_shift) {
+    // have a denormal float
+    int32_t shift = -am.power2 + 1;
+    cb(am, tinyobj_ff::min_val<int32_t>(shift, 64));
+    // check for round-up: if rounding-nearest carried us to the hidden bit.
+    am.power2 = (am.mantissa <
+                 (uint64_t(1) << binary_format<T>::mantissa_explicit_bits()))
+                    ? 0
+                    : 1;
+    return;
+  }
+
+  // have a normal float, use the default shift.
+  cb(am, mantissa_shift);
+
+  // check for carry
+  if (am.mantissa >=
+      (uint64_t(2) << binary_format<T>::mantissa_explicit_bits())) {
+    am.mantissa = (uint64_t(1) << binary_format<T>::mantissa_explicit_bits());
+    am.power2++;
+  }
+
+  // check for infinite: we could have carried to an infinite power
+  am.mantissa &= ~(uint64_t(1) << binary_format<T>::mantissa_explicit_bits());
+  if (am.power2 >= binary_format<T>::infinite_power()) {
+    am.power2 = binary_format<T>::infinite_power();
+    am.mantissa = 0;
+  }
+}
+
+template <typename callback>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 void
+round_nearest_tie_even(adjusted_mantissa &am, int32_t shift,
+                       callback cb) noexcept {
+  uint64_t const mask = (shift == 64) ? UINT64_MAX : (uint64_t(1) << shift) - 1;
+  uint64_t const halfway = (shift == 0) ? 0 : uint64_t(1) << (shift - 1);
+  uint64_t truncated_bits = am.mantissa & mask;
+  bool is_above = truncated_bits > halfway;
+  bool is_halfway = truncated_bits == halfway;
+
+  // shift digits into position
+  if (shift == 64) {
+    am.mantissa = 0;
+  } else {
+    am.mantissa >>= shift;
+  }
+  am.power2 += shift;
+
+  bool is_odd = (am.mantissa & 1) == 1;
+  am.mantissa += uint64_t(cb(is_odd, is_halfway, is_above));
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 void
+round_down(adjusted_mantissa &am, int32_t shift) noexcept {
+  if (shift == 64) {
+    am.mantissa = 0;
+  } else {
+    am.mantissa >>= shift;
+  }
+  am.power2 += shift;
+}
+
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
+skip_zeros(UC const *&first, UC const *last) noexcept {
+  uint64_t val;
+  while (!cpp20_and_in_constexpr() &&
+         tinyobj_ff::distance(first, last) >= int_cmp_len<UC>()) {
+    ::memcpy(&val, first, sizeof(uint64_t));
+    if (val != int_cmp_zeros<UC>()) {
+      break;
+    }
+    first += int_cmp_len<UC>();
+  }
+  while (first != last) {
+    if (*first != UC('0')) {
+      break;
+    }
+    first++;
+  }
+}
+
+// determine if any non-zero digits were truncated.
+// all characters must be valid digits.
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 bool
+is_truncated(UC const *first, UC const *last) noexcept {
+  // do 8-bit optimizations, can just compare to 8 literal 0s.
+  uint64_t val;
+  while (!cpp20_and_in_constexpr() &&
+         tinyobj_ff::distance(first, last) >= int_cmp_len<UC>()) {
+    ::memcpy(&val, first, sizeof(uint64_t));
+    if (val != int_cmp_zeros<UC>()) {
+      return true;
+    }
+    first += int_cmp_len<UC>();
+  }
+  while (first != last) {
+    if (*first != UC('0')) {
+      return true;
+    }
+    ++first;
+  }
+  return false;
+}
+
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 bool
+is_truncated(span<UC const> s) noexcept {
+  return is_truncated(s.ptr, s.ptr + s.len());
+}
+
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
+parse_eight_digits(UC const *&p, limb &value, size_t &counter,
+                   size_t &count) noexcept {
+  value = value * 100000000 + parse_eight_digits_unrolled(p);
+  p += 8;
+  counter += 8;
+  count += 8;
+}
+
+template <typename UC>
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14 void
+parse_one_digit(UC const *&p, limb &value, size_t &counter,
+                size_t &count) noexcept {
+  value = value * 10 + limb(*p - UC('0'));
+  p++;
+  counter++;
+  count++;
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
+add_native(bigint &big, limb power, limb value) noexcept {
+  big.mul(power);
+  big.add(value);
+}
+
+fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
+round_up_bigint(bigint &big, size_t &count) noexcept {
+  // need to round-up the digits, but need to avoid rounding
+  // ....9999 to ...10000, which could cause a false halfway point.
+  add_native(big, 10, 1);
+  count++;
+}
+
+// parse the significant digits into a big integer
+template <typename UC>
+inline FASTFLOAT_CONSTEXPR20 void
+parse_mantissa(bigint &result, parsed_number_string_t<UC> &num,
+               size_t max_digits, size_t &digits) noexcept {
+  // try to minimize the number of big integer and scalar multiplication.
+  // therefore, try to parse 8 digits at a time, and multiply by the largest
+  // scalar value (9 or 19 digits) for each step.
+  size_t counter = 0;
+  digits = 0;
+  limb value = 0;
+#ifdef FASTFLOAT_64BIT_LIMB
+  size_t step = 19;
+#else
+  size_t step = 9;
+#endif
+
+  // process all integer digits.
+  UC const *p = num.integer.ptr;
+  UC const *pend = p + num.integer.len();
+  skip_zeros(p, pend);
+  // process all digits, in increments of step per loop
+  while (p != pend) {
+    while ((tinyobj_ff::distance(p, pend) >= 8) && (step - counter >= 8) &&
+           (max_digits - digits >= 8)) {
+      parse_eight_digits(p, value, counter, digits);
+    }
+    while (counter < step && p != pend && digits < max_digits) {
+      parse_one_digit(p, value, counter, digits);
+    }
+    if (digits == max_digits) {
+      // add the temporary value, then check if we've truncated any digits
+      add_native(result, limb(powers_of_ten_uint64[counter]), value);
+      bool truncated = is_truncated(p, pend);
+      if (num.fraction.ptr != nullptr) {
+        truncated |= is_truncated(num.fraction);
+      }
+      if (truncated) {
+        round_up_bigint(result, digits);
+      }
+      return;
+    } else {
+      add_native(result, limb(powers_of_ten_uint64[counter]), value);
+      counter = 0;
+      value = 0;
+    }
+  }
+
+  // add our fraction digits, if they're available.
+  if (num.fraction.ptr != nullptr) {
+    p = num.fraction.ptr;
+    pend = p + num.fraction.len();
+    if (digits == 0) {
+      skip_zeros(p, pend);
+    }
+    // process all digits, in increments of step per loop
+    while (p != pend) {
+      while ((tinyobj_ff::distance(p, pend) >= 8) && (step - counter >= 8) &&
+             (max_digits - digits >= 8)) {
+        parse_eight_digits(p, value, counter, digits);
+      }
+      while (counter < step && p != pend && digits < max_digits) {
+        parse_one_digit(p, value, counter, digits);
+      }
+      if (digits == max_digits) {
+        // add the temporary value, then check if we've truncated any digits
+        add_native(result, limb(powers_of_ten_uint64[counter]), value);
+        bool truncated = is_truncated(p, pend);
+        if (truncated) {
+          round_up_bigint(result, digits);
+        }
+        return;
+      } else {
+        add_native(result, limb(powers_of_ten_uint64[counter]), value);
+        counter = 0;
+        value = 0;
+      }
+    }
+  }
+
+  if (counter != 0) {
+    add_native(result, limb(powers_of_ten_uint64[counter]), value);
+  }
+}
+
+template <typename T>
+inline FASTFLOAT_CONSTEXPR20 adjusted_mantissa
+positive_digit_comp(bigint &bigmant, int32_t exponent) noexcept {
+  FASTFLOAT_ASSERT(bigmant.pow10(uint32_t(exponent)));
+  adjusted_mantissa answer;
+  bool truncated;
+  answer.mantissa = bigmant.hi64(truncated);
+  int bias = binary_format<T>::mantissa_explicit_bits() -
+             binary_format<T>::minimum_exponent();
+  answer.power2 = bigmant.bit_length() - 64 + bias;
+
+  round<T>(answer, [truncated](adjusted_mantissa &a, int32_t shift) {
+    round_nearest_tie_even(
+        a, shift,
+        [truncated](bool is_odd, bool is_halfway, bool is_above) -> bool {
+          return is_above || (is_halfway && truncated) ||
+                 (is_odd && is_halfway);
+        });
+  });
+
+  return answer;
+}
+
+// the scaling here is quite simple: we have, for the real digits `m * 10^e`,
+// and for the theoretical digits `n * 2^f`. Since `e` is always negative,
+// to scale them identically, we do `n * 2^f * 5^-f`, so we now have `m * 2^e`.
+// we then need to scale by `2^(f- e)`, and then the two significant digits
+// are of the same magnitude.
+template <typename T>
+inline FASTFLOAT_CONSTEXPR20 adjusted_mantissa negative_digit_comp(
+    bigint &bigmant, adjusted_mantissa am, int32_t exponent) noexcept {
+  bigint &real_digits = bigmant;
+  int32_t real_exp = exponent;
+
+  // get the value of `b`, rounded down, and get a bigint representation of b+h
+  adjusted_mantissa am_b = am;
+  // gcc7 buf: use a lambda to remove the noexcept qualifier bug with
+  // -Wnoexcept-type.
+  round<T>(am_b,
+           [](adjusted_mantissa &a, int32_t shift) { round_down(a, shift); });
+  T b;
+  to_float(false, am_b, b);
+  adjusted_mantissa theor = to_extended_halfway(b);
+  bigint theor_digits(theor.mantissa);
+  int32_t theor_exp = theor.power2;
+
+  // scale real digits and theor digits to be same power.
+  int32_t pow2_exp = theor_exp - real_exp;
+  uint32_t pow5_exp = uint32_t(-real_exp);
+  if (pow5_exp != 0) {
+    FASTFLOAT_ASSERT(theor_digits.pow5(pow5_exp));
+  }
+  if (pow2_exp > 0) {
+    FASTFLOAT_ASSERT(theor_digits.pow2(uint32_t(pow2_exp)));
+  } else if (pow2_exp < 0) {
+    FASTFLOAT_ASSERT(real_digits.pow2(uint32_t(-pow2_exp)));
+  }
+
+  // compare digits, and use it to director rounding
+  int ord = real_digits.compare(theor_digits);
+  adjusted_mantissa answer = am;
+  round<T>(answer, [ord](adjusted_mantissa &a, int32_t shift) {
+    round_nearest_tie_even(
+        a, shift, [ord](bool is_odd, bool _, bool __) -> bool {
+          (void)_;  // not needed, since we've done our comparison
+          (void)__; // not needed, since we've done our comparison
+          if (ord > 0) {
+            return true;
+          } else if (ord < 0) {
+            return false;
+          } else {
+            return is_odd;
+          }
+        });
+  });
+
+  return answer;
+}
+
+// parse the significant digits as a big integer to unambiguously round the
+// the significant digits. here, we are trying to determine how to round
+// an extended float representation close to `b+h`, halfway between `b`
+// (the float rounded-down) and `b+u`, the next positive float. this
+// algorithm is always correct, and uses one of two approaches. when
+// the exponent is positive relative to the significant digits (such as
+// 1234), we create a big-integer representation, get the high 64-bits,
+// determine if any lower bits are truncated, and use that to direct
+// rounding. in case of a negative exponent relative to the significant
+// digits (such as 1.2345), we create a theoretical representation of
+// `b` as a big-integer type, scaled to the same binary exponent as
+// the actual digits. we then compare the big integer representations
+// of both, and use that to direct rounding.
+template <typename T, typename UC>
+inline FASTFLOAT_CONSTEXPR20 adjusted_mantissa
+digit_comp(parsed_number_string_t<UC> &num, adjusted_mantissa am) noexcept {
+  // remove the invalid exponent bias
+  am.power2 -= invalid_am_bias;
+
+  int32_t sci_exp = scientific_exponent(num);
+  size_t max_digits = binary_format<T>::max_digits();
+  size_t digits = 0;
+  bigint bigmant;
+  parse_mantissa(bigmant, num, max_digits, digits);
+  // can't underflow, since digits is at most max_digits.
+  int32_t exponent = sci_exp + 1 - int32_t(digits);
+  if (exponent >= 0) {
+    return positive_digit_comp<T>(bigmant, exponent);
+  } else {
+    return negative_digit_comp<T>(bigmant, am, exponent);
+  }
+}
+
+} // namespace fast_float
+
+#endif
+
+#ifndef FASTFLOAT_PARSE_NUMBER_H
+#define FASTFLOAT_PARSE_NUMBER_H
+
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace fast_float {
+
+namespace detail {
+/**
+ * Special case +inf, -inf, nan, infinity, -infinity.
+ * The case comparisons could be made much faster given that we know that the
+ * strings a null-free and fixed.
+ **/
+template <typename T, typename UC>
+from_chars_result_t<UC>
+    FASTFLOAT_CONSTEXPR14 parse_infnan(UC const *first, UC const *last,
+                                       T &value, chars_format fmt) noexcept {
+  from_chars_result_t<UC> answer{};
+  answer.ptr = first;
+  answer.ec = tinyobj_ff::ff_errc(); // be optimistic
+  // assume first < last, so dereference without checks;
+  bool const minusSign = (*first == UC('-'));
+  // C++17 20.19.3.(7.1) explicitly forbids '+' sign here
+  if ((*first == UC('-')) ||
+      (uint64_t(fmt & chars_format::allow_leading_plus) &&
+       (*first == UC('+')))) {
+    ++first;
+  }
+  if (last - first >= 3) {
+    if (fastfloat_strncasecmp(first, str_const_nan<UC>(), 3)) {
+      answer.ptr = (first += 3);
+      value = minusSign ? -std::numeric_limits<T>::quiet_NaN()
+                        : std::numeric_limits<T>::quiet_NaN();
+      // Check for possible nan(n-char-seq-opt), C++17 20.19.3.7,
+      // C11 7.20.1.3.3. At least MSVC produces nan(ind) and nan(snan).
+      if (first != last && *first == UC('(')) {
+        for (UC const *ptr = first + 1; ptr != last; ++ptr) {
+          if (*ptr == UC(')')) {
+            answer.ptr = ptr + 1; // valid nan(n-char-seq-opt)
+            break;
+          } else if (!((UC('a') <= *ptr && *ptr <= UC('z')) ||
+                       (UC('A') <= *ptr && *ptr <= UC('Z')) ||
+                       (UC('0') <= *ptr && *ptr <= UC('9')) || *ptr == UC('_')))
+            break; // forbidden char, not nan(n-char-seq-opt)
+        }
+      }
+      return answer;
+    }
+    if (fastfloat_strncasecmp(first, str_const_inf<UC>(), 3)) {
+      if ((last - first >= 8) &&
+          fastfloat_strncasecmp(first + 3, str_const_inf<UC>() + 3, 5)) {
+        answer.ptr = first + 8;
+      } else {
+        answer.ptr = first + 3;
+      }
+      value = minusSign ? -std::numeric_limits<T>::infinity()
+                        : std::numeric_limits<T>::infinity();
+      return answer;
+    }
+  }
+  answer.ec = tinyobj_ff::ff_errc::invalid_argument;
+  return answer;
+}
+
+/**
+ * Returns true if the floating-pointing rounding mode is to 'nearest'.
+ * It is the default on most system. This function is meant to be inexpensive.
+ * Credit : @mwalcott3
+ */
+fastfloat_really_inline bool rounds_to_nearest() noexcept {
+  // https://lemire.me/blog/2020/06/26/gcc-not-nearest/
+#if (FLT_EVAL_METHOD != 1) && (FLT_EVAL_METHOD != 0)
+  return false;
+#endif
+  // See
+  // A fast function to check your floating-point rounding mode
+  // https://lemire.me/blog/2022/11/16/a-fast-function-to-check-your-floating-point-rounding-mode/
+  //
+  // This function is meant to be equivalent to :
+  // prior: #include <cfenv>
+  //  return fegetround() == FE_TONEAREST;
+  // However, it is expected to be much faster than the fegetround()
+  // function call.
+  //
+  // The volatile keyword prevents the compiler from computing the function
+  // at compile-time.
+  // There might be other ways to prevent compile-time optimizations (e.g.,
+  // asm). The value does not need to be std::numeric_limits<float>::min(), any
+  // small value so that 1 + x should round to 1 would do (after accounting for
+  // excess precision, as in 387 instructions).
+  static float volatile fmin = std::numeric_limits<float>::min();
+  float fmini = fmin; // we copy it so that it gets loaded at most once.
+//
+// Explanation:
+// Only when fegetround() == FE_TONEAREST do we have that
+// fmin + 1.0f == 1.0f - fmin.
+//
+// FE_UPWARD:
+//  fmin + 1.0f > 1
+//  1.0f - fmin == 1
+//
+// FE_DOWNWARD or  FE_TOWARDZERO:
+//  fmin + 1.0f == 1
+//  1.0f - fmin < 1
+//
+// Note: This may fail to be accurate if fast-math has been
+// enabled, as rounding conventions may not apply.
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(push)
+//  todo: is there a VS warning?
+//  see
+//  https://stackoverflow.com/questions/46079446/is-there-a-warning-for-floating-point-equality-checking-in-visual-studio-2013
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+  return (fmini + 1.0f == 1.0f - fmini);
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(pop)
+#elif defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+}
+
+} // namespace detail
+
+template <typename T> struct from_chars_caller {
+  template <typename UC>
+  FASTFLOAT_CONSTEXPR20 static from_chars_result_t<UC>
+  call(UC const *first, UC const *last, T &value,
+       parse_options_t<UC> options) noexcept {
+    return from_chars_advanced(first, last, value, options);
+  }
+};
+
+#ifdef __STDCPP_FLOAT32_T__
+template <> struct from_chars_caller<std::float32_t> {
+  template <typename UC>
+  FASTFLOAT_CONSTEXPR20 static from_chars_result_t<UC>
+  call(UC const *first, UC const *last, std::float32_t &value,
+       parse_options_t<UC> options) noexcept {
+    // if std::float32_t is defined, and we are in C++23 mode; macro set for
+    // float32; set value to float due to equivalence between float and
+    // float32_t
+    float val;
+    auto ret = from_chars_advanced(first, last, val, options);
+    value = val;
+    return ret;
+  }
+};
+#endif
+
+#ifdef __STDCPP_FLOAT64_T__
+template <> struct from_chars_caller<std::float64_t> {
+  template <typename UC>
+  FASTFLOAT_CONSTEXPR20 static from_chars_result_t<UC>
+  call(UC const *first, UC const *last, std::float64_t &value,
+       parse_options_t<UC> options) noexcept {
+    // if std::float64_t is defined, and we are in C++23 mode; macro set for
+    // float64; set value as double due to equivalence between double and
+    // float64_t
+    double val;
+    auto ret = from_chars_advanced(first, last, val, options);
+    value = val;
+    return ret;
+  }
+};
+#endif
+
+template <typename T, typename UC, typename>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars(UC const *first, UC const *last, T &value,
+           chars_format fmt /*= chars_format::general*/) noexcept {
+  return from_chars_caller<T>::call(first, last, value,
+                                    parse_options_t<UC>(fmt));
+}
+
+/**
+ * This function overload takes parsed_number_string_t structure that is created
+ * and populated either by from_chars_advanced function taking chars range and
+ * parsing options or other parsing custom function implemented by user.
+ */
+template <typename T, typename UC>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars_advanced(parsed_number_string_t<UC> &pns, T &value) noexcept {
+
+  static_assert(is_supported_float_type<T>::value,
+                "only some floating-point types are supported");
+  static_assert(is_supported_char_type<UC>::value,
+                "only char, wchar_t, char16_t and char32_t are supported");
+
+  from_chars_result_t<UC> answer;
+
+  answer.ec = tinyobj_ff::ff_errc(); // be optimistic
+  answer.ptr = pns.lastmatch;
+  // The implementation of the Clinger's fast path is convoluted because
+  // we want round-to-nearest in all cases, irrespective of the rounding mode
+  // selected on the thread.
+  // We proceed optimistically, assuming that detail::rounds_to_nearest()
+  // returns true.
+  if (binary_format<T>::min_exponent_fast_path() <= pns.exponent &&
+      pns.exponent <= binary_format<T>::max_exponent_fast_path() &&
+      !pns.too_many_digits) {
+    // Unfortunately, the conventional Clinger's fast path is only possible
+    // when the system rounds to the nearest float.
+    //
+    // We expect the next branch to almost always be selected.
+    // We could check it first (before the previous branch), but
+    // there might be performance advantages at having the check
+    // be last.
+    if (!cpp20_and_in_constexpr() && detail::rounds_to_nearest()) {
+      // We have that fegetround() == FE_TONEAREST.
+      // Next is Clinger's fast path.
+      if (pns.mantissa <= binary_format<T>::max_mantissa_fast_path()) {
+        value = T(pns.mantissa);
+        if (pns.exponent < 0) {
+          value = value / binary_format<T>::exact_power_of_ten(-pns.exponent);
+        } else {
+          value = value * binary_format<T>::exact_power_of_ten(pns.exponent);
+        }
+        if (pns.negative) {
+          value = -value;
+        }
+        return answer;
+      }
+    } else {
+      // We do not have that fegetround() == FE_TONEAREST.
+      // Next is a modified Clinger's fast path, inspired by Jakub Jelínek's
+      // proposal
+      if (pns.exponent >= 0 &&
+          pns.mantissa <=
+              binary_format<T>::max_mantissa_fast_path(pns.exponent)) {
+#if defined(__clang__) || defined(FASTFLOAT_32BIT)
+        // Clang may map 0 to -0.0 when fegetround() == FE_DOWNWARD
+        if (pns.mantissa == 0) {
+          value = pns.negative ? T(-0.) : T(0.);
+          return answer;
+        }
+#endif
+        value = T(pns.mantissa) *
+                binary_format<T>::exact_power_of_ten(pns.exponent);
+        if (pns.negative) {
+          value = -value;
+        }
+        return answer;
+      }
+    }
+  }
+  adjusted_mantissa am =
+      compute_float<binary_format<T>>(pns.exponent, pns.mantissa);
+  if (pns.too_many_digits && am.power2 >= 0) {
+    if (am != compute_float<binary_format<T>>(pns.exponent, pns.mantissa + 1)) {
+      am = compute_error<binary_format<T>>(pns.exponent, pns.mantissa);
+    }
+  }
+  // If we called compute_float<binary_format<T>>(pns.exponent, pns.mantissa)
+  // and we have an invalid power (am.power2 < 0), then we need to go the long
+  // way around again. This is very uncommon.
+  if (am.power2 < 0) {
+    am = digit_comp<T>(pns, am);
+  }
+  to_float(pns.negative, am, value);
+  // Test for over/underflow.
+  if ((pns.mantissa != 0 && am.mantissa == 0 && am.power2 == 0) ||
+      am.power2 == binary_format<T>::infinite_power()) {
+    answer.ec = tinyobj_ff::ff_errc::result_out_of_range;
+  }
+  return answer;
+}
+
+template <typename T, typename UC>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars_float_advanced(UC const *first, UC const *last, T &value,
+                          parse_options_t<UC> options) noexcept {
+
+  static_assert(is_supported_float_type<T>::value,
+                "only some floating-point types are supported");
+  static_assert(is_supported_char_type<UC>::value,
+                "only char, wchar_t, char16_t and char32_t are supported");
+
+  chars_format const fmt = detail::adjust_for_feature_macros(options.format);
+
+  from_chars_result_t<UC> answer;
+  if (uint64_t(fmt & chars_format::skip_white_space)) {
+    while ((first != last) && fast_float::is_space(*first)) {
+      first++;
+    }
+  }
+  if (first == last) {
+    answer.ec = tinyobj_ff::ff_errc::invalid_argument;
+    answer.ptr = first;
+    return answer;
+  }
+  parsed_number_string_t<UC> pns =
+      uint64_t(fmt & detail::basic_json_fmt)
+          ? parse_number_string<true, UC>(first, last, options)
+          : parse_number_string<false, UC>(first, last, options);
+  if (!pns.valid) {
+    if (uint64_t(fmt & chars_format::no_infnan)) {
+      answer.ec = tinyobj_ff::ff_errc::invalid_argument;
+      answer.ptr = first;
+      return answer;
+    } else {
+      return detail::parse_infnan(first, last, value, fmt);
+    }
+  }
+
+  // call overload that takes parsed_number_string_t directly.
+  return from_chars_advanced(pns, value);
+}
+
+template <typename T, typename UC, typename>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars(UC const *first, UC const *last, T &value, int base) noexcept {
+
+  static_assert(is_supported_integer_type<T>::value,
+                "only integer types are supported");
+  static_assert(is_supported_char_type<UC>::value,
+                "only char, wchar_t, char16_t and char32_t are supported");
+
+  parse_options_t<UC> options;
+  options.base = base;
+  return from_chars_advanced(first, last, value, options);
+}
+
+template <typename T, typename UC>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars_int_advanced(UC const *first, UC const *last, T &value,
+                        parse_options_t<UC> options) noexcept {
+
+  static_assert(is_supported_integer_type<T>::value,
+                "only integer types are supported");
+  static_assert(is_supported_char_type<UC>::value,
+                "only char, wchar_t, char16_t and char32_t are supported");
+
+  chars_format const fmt = detail::adjust_for_feature_macros(options.format);
+  int const base = options.base;
+
+  from_chars_result_t<UC> answer;
+  if (uint64_t(fmt & chars_format::skip_white_space)) {
+    while ((first != last) && fast_float::is_space(*first)) {
+      first++;
+    }
+  }
+  if (first == last || base < 2 || base > 36) {
+    answer.ec = tinyobj_ff::ff_errc::invalid_argument;
+    answer.ptr = first;
+    return answer;
+  }
+
+  return parse_int_string(first, last, value, options);
+}
+
+template <size_t TypeIx> struct from_chars_advanced_caller {
+  static_assert(TypeIx > 0, "unsupported type");
+};
+
+template <> struct from_chars_advanced_caller<1> {
+  template <typename T, typename UC>
+  FASTFLOAT_CONSTEXPR20 static from_chars_result_t<UC>
+  call(UC const *first, UC const *last, T &value,
+       parse_options_t<UC> options) noexcept {
+    return from_chars_float_advanced(first, last, value, options);
+  }
+};
+
+template <> struct from_chars_advanced_caller<2> {
+  template <typename T, typename UC>
+  FASTFLOAT_CONSTEXPR20 static from_chars_result_t<UC>
+  call(UC const *first, UC const *last, T &value,
+       parse_options_t<UC> options) noexcept {
+    return from_chars_int_advanced(first, last, value, options);
+  }
+};
+
+template <typename T, typename UC>
+FASTFLOAT_CONSTEXPR20 from_chars_result_t<UC>
+from_chars_advanced(UC const *first, UC const *last, T &value,
+                    parse_options_t<UC> options) noexcept {
+  return from_chars_advanced_caller<
+      size_t(is_supported_float_type<T>::value) +
+      2 * size_t(is_supported_integer_type<T>::value)>::call(first, last, value,
+                                                             options);
+}
+
+} // namespace fast_float
+
+#endif
+
+
+// --- End embedded fast_float ---
+
+// Clean up fast_float macros to avoid polluting the user's namespace.
+#undef FASTFLOAT_32BIT
+#undef FASTFLOAT_32BIT_LIMB
+#undef FASTFLOAT_64BIT
+#undef FASTFLOAT_64BIT_LIMB
+#undef FASTFLOAT_ASCII_NUMBER_H
+#undef FASTFLOAT_ASSERT
+#undef FASTFLOAT_BIGINT_H
+#undef FASTFLOAT_CONSTEXPR14
+#undef FASTFLOAT_CONSTEXPR20
+#undef FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
+#undef FASTFLOAT_DEBUG_ASSERT
+#undef FASTFLOAT_DECIMAL_TO_BINARY_H
+#undef FASTFLOAT_DETAIL_MUST_DEFINE_CONSTEXPR_VARIABLE
+#undef FASTFLOAT_DIGIT_COMPARISON_H
+#undef FASTFLOAT_ENABLE_IF
+#undef FASTFLOAT_FAST_FLOAT_H
+#undef FASTFLOAT_FAST_TABLE_H
+#undef FASTFLOAT_FLOAT_COMMON_H
+#undef FASTFLOAT_HAS_BIT_CAST
+#undef FASTFLOAT_HAS_IS_CONSTANT_EVALUATED
+#undef FASTFLOAT_HAS_SIMD
+#undef FASTFLOAT_IF_CONSTEXPR17
+#undef FASTFLOAT_IS_BIG_ENDIAN
+#undef FASTFLOAT_IS_CONSTEXPR
+#undef FASTFLOAT_NEON
+#undef FASTFLOAT_PARSE_NUMBER_H
+#undef fastfloat_really_inline
+#undef FASTFLOAT_SIMD_DISABLE_WARNINGS
+#undef FASTFLOAT_SIMD_RESTORE_WARNINGS
+#undef FASTFLOAT_SSE2
+#undef FASTFLOAT_STRINGIZE
+#undef FASTFLOAT_STRINGIZE_IMPL
+#undef FASTFLOAT_TRY
+#undef FASTFLOAT_VERSION
+#undef FASTFLOAT_VERSION_MAJOR
+#undef FASTFLOAT_VERSION_MINOR
+#undef FASTFLOAT_VERSION_PATCH
+#undef FASTFLOAT_VERSION_STR
+#undef FASTFLOAT_VISUAL_STUDIO
+
+#endif  // TINYOBJLOADER_DISABLE_FAST_FLOAT
+
+namespace tinyobj {
+
+MaterialReader::~MaterialReader() {}
+
+// Byte-stream reader for bounds-checked text parsing.
+// Replaces raw `const char*` token pointers with `(buf, len, idx)` triple.
+// Every byte access is guarded by an EOF check.
+class StreamReader {
+ public:
+// Maximum number of bytes StreamReader will buffer from std::istream.
+// Define this macro to a larger value if your application needs to parse
+// very large streamed OBJ/MTL content.
+#ifndef TINYOBJLOADER_STREAM_READER_MAX_BYTES
+#define TINYOBJLOADER_STREAM_READER_MAX_BYTES (size_t(256) * size_t(1024) * size_t(1024))
+#endif
+
+  StreamReader(const char *buf, size_t length)
+      : buf_(buf), length_(length), idx_(0), line_num_(1), col_num_(1) {}
+
+  // Non-copyable, non-movable: buf_ may point into owned_buf_.
+  StreamReader(const StreamReader &) /* = delete */;
+  StreamReader &operator=(const StreamReader &) /* = delete */;
+
+  // Build from std::istream by reading all content into an internal buffer.
+  explicit StreamReader(std::istream &is) : buf_(NULL), length_(0), idx_(0), line_num_(1), col_num_(1) {
+    const size_t max_stream_bytes = TINYOBJLOADER_STREAM_READER_MAX_BYTES;
+    std::streampos start_pos = is.tellg();
+    bool can_seek = (start_pos != std::streampos(-1));
+    if (can_seek) {
+      is.seekg(0, std::ios::end);
+      std::streampos end_pos = is.tellg();
+      if (end_pos >= start_pos) {
+        std::streamoff remaining_off = static_cast<std::streamoff>(end_pos - start_pos);
+        is.seekg(start_pos);
+        unsigned long long remaining_ull = static_cast<unsigned long long>(remaining_off);
+        if (remaining_ull > static_cast<unsigned long long>((std::numeric_limits<size_t>::max)())) {
+          std::stringstream ss;
+          ss << "input stream too large for this platform (" << remaining_ull
+             << " bytes exceeds size_t max " << (std::numeric_limits<size_t>::max)() << ")\n";
+          push_error(ss.str());
+          buf_ = "";
+          length_ = 0;
+          return;
+        }
+        size_t remaining_size = static_cast<size_t>(remaining_ull);
+        if (remaining_size > max_stream_bytes) {
+          std::stringstream ss;
+          ss << "input stream too large (" << remaining_size
+             << " bytes exceeds limit " << max_stream_bytes << " bytes)\n";
+          push_error(ss.str());
+          buf_ = "";
+          length_ = 0;
+          return;
+        }
+        owned_buf_.resize(remaining_size);
+        if (remaining_size > 0) {
+          is.read(&owned_buf_[0], static_cast<std::streamsize>(remaining_size));
+        }
+        size_t actually_read = static_cast<size_t>(is.gcount());
+        owned_buf_.resize(actually_read);
+      }
+    }
+    if (!can_seek || owned_buf_.empty()) {
+      // Stream doesn't support seeking, or seek probing failed.
+      if (can_seek) is.seekg(start_pos);
+      is.clear();
+      std::vector<char> content;
+      char chunk[4096];
+      size_t total_read = 0;
+      while (is.good()) {
+        is.read(chunk, static_cast<std::streamsize>(sizeof(chunk)));
+        std::streamsize nread = is.gcount();
+        if (nread <= 0) break;
+        size_t n = static_cast<size_t>(nread);
+        if (n > (max_stream_bytes - total_read)) {
+          std::stringstream ss;
+          ss << "input stream too large (exceeds limit " << max_stream_bytes
+             << " bytes)\n";
+          push_error(ss.str());
+          owned_buf_.clear();
+          buf_ = "";
+          length_ = 0;
+          return;
+        }
+        content.insert(content.end(), chunk, chunk + n);
+        total_read += n;
+      }
+      owned_buf_.swap(content);
+    }
+    buf_ = owned_buf_.empty() ? "" : &owned_buf_[0];
+    length_ = owned_buf_.size();
+  }
+
+  bool eof() const { return idx_ >= length_; }
+  size_t tell() const { return idx_; }
+  size_t size() const { return length_; }
+  size_t line_num() const { return line_num_; }
+  size_t col_num() const { return col_num_; }
+
+  char peek() const {
+    if (idx_ >= length_) return '\0';
+    return buf_[idx_];
+  }
+
+  char get() {
+    if (idx_ >= length_) return '\0';
+    char c = buf_[idx_++];
+    if (c == '\n') { line_num_++; col_num_ = 1; } else { col_num_++; }
+    return c;
+  }
+
+  void advance(size_t n) {
+    for (size_t i = 0; i < n && idx_ < length_; i++) {
+      if (buf_[idx_] == '\n') { line_num_++; col_num_ = 1; } else { col_num_++; }
+      idx_++;
+    }
+  }
+
+  void skip_space() {
+    while (idx_ < length_ && (buf_[idx_] == ' ' || buf_[idx_] == '\t')) {
+      col_num_++;
+      idx_++;
+    }
+  }
+
+  void skip_space_and_cr() {
+    while (idx_ < length_ && (buf_[idx_] == ' ' || buf_[idx_] == '\t' || buf_[idx_] == '\r')) {
+      col_num_++;
+      idx_++;
+    }
+  }
+
+  void skip_line() {
+    while (idx_ < length_) {
+      char c = buf_[idx_];
+      if (c == '\n') {
+        idx_++;
+        line_num_++;
+        col_num_ = 1;
+        return;
+      }
+      if (c == '\r') {
+        idx_++;
+        if (idx_ < length_ && buf_[idx_] == '\n') {
+          idx_++;
+        }
+        line_num_++;
+        col_num_ = 1;
+        return;
+      }
+      col_num_++;
+      idx_++;
+    }
+  }
+
+  bool at_line_end() const {
+    if (idx_ >= length_) return true;
+    char c = buf_[idx_];
+    return (c == '\n' || c == '\r' || c == '\0');
+  }
+
+  std::string read_line() {
+    std::string result;
+    while (idx_ < length_) {
+      char c = buf_[idx_];
+      if (c == '\n' || c == '\r') break;
+      result += c;
+      col_num_++;
+      idx_++;
+    }
+    return result;
+  }
+
+  // Reads a whitespace-delimited token. Used by tests and as a general utility.
+  std::string read_token() {
+    skip_space();
+    std::string result;
+    while (idx_ < length_) {
+      char c = buf_[idx_];
+      if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\0') break;
+      result += c;
+      col_num_++;
+      idx_++;
+    }
+    return result;
+  }
+
+  bool match(const char *prefix, size_t len) const {
+    if (idx_ >= length_ || len > length_ - idx_) return false;
+    return (memcmp(buf_ + idx_, prefix, len) == 0);
+  }
+
+  bool char_at(size_t offset, char c) const {
+    if (idx_ >= length_ || offset >= length_ - idx_) return false;
+    return buf_[idx_ + offset] == c;
+  }
+
+  char peek_at(size_t offset) const {
+    if (idx_ >= length_ || offset >= length_ - idx_) return '\0';
+    return buf_[idx_ + offset];
+  }
+
+  const char *current_ptr() const {
+    if (idx_ >= length_) return "";
+    return buf_ + idx_;
+  }
+
+  size_t remaining() const {
+    return (idx_ < length_) ? (length_ - idx_) : 0;
+  }
+
+  // Returns the full text of the current line (for diagnostic display).
+  std::string current_line_text() const {
+    // Scan backward to find line start
+    size_t line_start = idx_;
+    while (line_start > 0 && buf_[line_start - 1] != '\n' && buf_[line_start - 1] != '\r') {
+      line_start--;
+    }
+    // Scan forward to find line end
+    size_t line_end = idx_;
+    while (line_end < length_ && buf_[line_end] != '\n' && buf_[line_end] != '\r') {
+      line_end++;
+    }
+    return std::string(buf_ + line_start, line_end - line_start);
+  }
+
+  // Clang-style formatted error with file:line:col and caret.
+  std::string format_error(const std::string &filename, const std::string &msg) const {
+    std::stringstream line_ss, col_ss;
+    line_ss << line_num_;
+    col_ss << col_num_;
+    std::string result;
+    result += filename + ":" + line_ss.str() + ":" + col_ss.str() + ": error: " + msg + "\n";
+    std::string line_text = current_line_text();
+    result += line_text + "\n";
+    // Build caret line preserving tab alignment
+    std::string caret;
+    size_t caret_pos = (col_num_ > 0) ? (col_num_ - 1) : 0;
+    for (size_t i = 0; i < caret_pos && i < line_text.size(); i++) {
+      caret += (line_text[i] == '\t') ? '\t' : ' ';
+    }
+    caret += "^";
+    result += caret + "\n";
+    return result;
+  }
+
+  std::string format_error(const std::string &msg) const {
+    return format_error("<input>", msg);
+  }
+
+  // Error stack
+  void push_error(const std::string &msg) {
+    errors_.push_back(msg);
+  }
+
+  void push_formatted_error(const std::string &filename, const std::string &msg) {
+    errors_.push_back(format_error(filename, msg));
+  }
+
+  bool has_errors() const { return !errors_.empty(); }
+
+  std::string get_errors() const {
+    std::string result;
+    for (size_t i = 0; i < errors_.size(); i++) {
+      result += errors_[i];
+    }
+    return result;
+  }
+
+  const std::vector<std::string> &error_stack() const { return errors_; }
+
+  void clear_errors() { errors_.clear(); }
+
+ private:
+  const char *buf_;
+  size_t length_;
+  size_t idx_;
+  size_t line_num_;
+  size_t col_num_;
+  std::vector<char> owned_buf_;
+  std::vector<std::string> errors_;
+};
+
+#ifdef TINYOBJLOADER_USE_MMAP
+// RAII wrapper for memory-mapped file I/O.
+// Opens a file and maps it into memory; the mapping is released on destruction.
+// For empty files, data is set to "" and is_mapped remains false so close()
+// will not attempt to unmap a string literal.
+struct MappedFile {
+  const char *data;
+  size_t size;
+  bool is_mapped;  // true when data points to an actual mapped region
+#if defined(_WIN32)
+  HANDLE hFile;
+  HANDLE hMapping;
+#else
+  void *mapped_ptr;
+#endif
+
+  MappedFile() : data(NULL), size(0), is_mapped(false)
+#if defined(_WIN32)
+    , hFile(INVALID_HANDLE_VALUE), hMapping(NULL)
+#else
+    , mapped_ptr(NULL)
+#endif
+  {}
+
+  // Opens and maps the file. Returns true on success.
+  bool open(const char *filepath) {
+#if defined(_WIN32)
+    std::wstring wfilepath = LongPathW(UTF8ToWchar(std::string(filepath)));
+    hFile = CreateFileW(wfilepath.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) return false;
+    LARGE_INTEGER fileSize;
+    if (!GetFileSizeEx(hFile, &fileSize)) { close(); return false; }
+    if (fileSize.QuadPart < 0) { close(); return false; }
+    unsigned long long fsize = static_cast<unsigned long long>(fileSize.QuadPart);
+    if (fsize > static_cast<unsigned long long>((std::numeric_limits<size_t>::max)())) {
+      close();
+      return false;
+    }
+    size = static_cast<size_t>(fsize);
+    if (size == 0) { data = ""; return true; }  // valid but empty; is_mapped stays false
+    hMapping = CreateFileMappingA(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
+    if (hMapping == NULL) { close(); return false; }
+    data = static_cast<const char *>(MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, 0));
+    if (!data) { close(); return false; }
+    is_mapped = true;
+    return true;
+#else
+    int fd = ::open(filepath, O_RDONLY);
+    if (fd == -1) return false;
+    struct stat sb;
+    if (fstat(fd, &sb) != 0) { ::close(fd); return false; }
+    if (sb.st_size < 0) { ::close(fd); return false; }
+    if (static_cast<unsigned long long>(sb.st_size) >
+        static_cast<unsigned long long>((std::numeric_limits<size_t>::max)())) {
+      ::close(fd);
+      return false;
+    }
+    size = static_cast<size_t>(sb.st_size);
+    if (size == 0) { ::close(fd); data = ""; return true; }  // valid but empty
+    mapped_ptr = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    ::close(fd);
+    if (mapped_ptr == MAP_FAILED) { mapped_ptr = NULL; size = 0; return false; }
+    data = static_cast<const char *>(mapped_ptr);
+    is_mapped = true;
+    return true;
+#endif
+  }
+
+  void close() {
+#if defined(_WIN32)
+    if (is_mapped && data) { UnmapViewOfFile(data); }
+    data = NULL;
+    is_mapped = false;
+    if (hMapping != NULL) { CloseHandle(hMapping); hMapping = NULL; }
+    if (hFile != INVALID_HANDLE_VALUE) { CloseHandle(hFile); hFile = INVALID_HANDLE_VALUE; }
+#else
+    if (is_mapped && mapped_ptr && mapped_ptr != MAP_FAILED) { munmap(mapped_ptr, size); }
+    mapped_ptr = NULL;
+    data = NULL;
+    is_mapped = false;
+#endif
+    size = 0;
+  }
+
+  ~MappedFile() { close(); }
+
+ private:
+  MappedFile(const MappedFile &);             // non-copyable
+  MappedFile &operator=(const MappedFile &);  // non-copyable
+};
+#endif  // TINYOBJLOADER_USE_MMAP
+
+
+struct vertex_index_t {
+  int v_idx, vt_idx, vn_idx;
+  vertex_index_t() : v_idx(-1), vt_idx(-1), vn_idx(-1) {}
+  explicit vertex_index_t(int idx) : v_idx(idx), vt_idx(idx), vn_idx(idx) {}
+  vertex_index_t(int vidx, int vtidx, int vnidx)
+      : v_idx(vidx), vt_idx(vtidx), vn_idx(vnidx) {}
+};
+
+// Internal data structure for face representation
+// index + smoothing group.
+struct face_t {
+  unsigned int
+      smoothing_group_id;  // smoothing group id. 0 = smoothing groupd is off.
+  int pad_;
+  std::vector<vertex_index_t> vertex_indices;  // face vertex indices.
+
+  face_t() : smoothing_group_id(0), pad_(0) {}
+};
+
+// Internal data structure for line representation
+struct __line_t {
+  // l v1/vt1 v2/vt2 ...
+  // In the specification, line primitrive does not have normal index, but
+  // TinyObjLoader allow it
+  std::vector<vertex_index_t> vertex_indices;
+};
+
+// Internal data structure for points representation
+struct __points_t {
+  // p v1 v2 ...
+  // In the specification, point primitrive does not have normal index and
+  // texture coord index, but TinyObjLoader allow it.
+  std::vector<vertex_index_t> vertex_indices;
+};
+
+struct tag_sizes {
+  tag_sizes() : num_ints(0), num_reals(0), num_strings(0) {}
+  int num_ints;
+  int num_reals;
+  int num_strings;
+};
+
+struct obj_shape {
+  std::vector<real_t> v;
+  std::vector<real_t> vn;
+  std::vector<real_t> vt;
+};
+
+//
+// Manages group of primitives(face, line, points, ...)
+struct PrimGroup {
+  std::vector<face_t> faceGroup;
+  std::vector<__line_t> lineGroup;
+  std::vector<__points_t> pointsGroup;
+
+  void clear() {
+    faceGroup.clear();
+    lineGroup.clear();
+    pointsGroup.clear();
+  }
+
+  bool IsEmpty() const {
+    return faceGroup.empty() && lineGroup.empty() && pointsGroup.empty();
+  }
+
+  // TODO(syoyo): bspline, surface, ...
+};
+
+// See
+// http://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
+#define IS_SPACE(x) (((x) == ' ') || ((x) == '\t'))
+#define IS_DIGIT(x) \
+  (static_cast<unsigned int>((x) - '0') < static_cast<unsigned int>(10))
+#define IS_NEW_LINE(x) (((x) == '\r') || ((x) == '\n') || ((x) == '\0'))
+
+template <typename T>
+static inline std::string toString(const T &t) {
+  std::stringstream ss;
+  ss << t;
+  return ss.str();
+}
+
+static inline std::string removeUtf8Bom(const std::string& input) {
+    // UTF-8 BOM = 0xEF,0xBB,0xBF
+    if (input.size() >= 3 &&
+        static_cast<unsigned char>(input[0]) == 0xEF &&
+        static_cast<unsigned char>(input[1]) == 0xBB &&
+        static_cast<unsigned char>(input[2]) == 0xBF) {
+        return input.substr(3); // Skip BOM
+    }
+    return input;
+}
+
+// Trim trailing spaces and tabs from a string.
+static inline std::string trimTrailingWhitespace(const std::string &s) {
+  size_t end = s.find_last_not_of(" \t");
+  if (end == std::string::npos) return "";
+  return s.substr(0, end + 1);
+}
+
+struct warning_context {
+  std::string *warn;
+  size_t line_number;
+  std::string filename;
+};
+
+// Safely convert size_t to int, clamping at INT_MAX to prevent overflow.
+static inline int size_to_int(size_t sz) {
+  return sz > static_cast<size_t>(INT_MAX) ? INT_MAX : static_cast<int>(sz);
+}
+
+// Make index zero-base, and also support relative index.
+static inline bool fixIndex(int idx, int n, int *ret, bool allow_zero,
+                            const warning_context &context) {
+  if (!ret) {
+    return false;
+  }
+
+  if (idx > 0) {
+    (*ret) = idx - 1;
+    return true;
+  }
+
+  if (idx == 0) {
+    // zero is not allowed according to the spec.
+    if (context.warn) {
+      (*context.warn) +=
+          context.filename + ":" + toString(context.line_number) +
+          ": warning: zero value index found (will have a value of -1 for "
+          "normal and tex indices)\n";
+    }
+
+    (*ret) = idx - 1;
+    return allow_zero;
+  }
+
+  if (idx < 0) {
+    (*ret) = n + idx;  // negative value = relative
+    if ((*ret) < 0) {
+      return false;  // invalid relative index
+    }
+    return true;
+  }
+
+  return false;  // never reach here.
+}
+
+static inline std::string parseString(const char **token) {
+  std::string s;
+  (*token) += strspn((*token), " \t");
+  size_t e = strcspn((*token), " \t\r");
+  s = std::string((*token), &(*token)[e]);
+  (*token) += e;
+  return s;
+}
+
+static inline int parseInt(const char **token) {
+  (*token) += strspn((*token), " \t");
+  int i = atoi((*token));
+  (*token) += strcspn((*token), " \t\r");
+  return i;
+}
+
+#ifndef TINYOBJLOADER_DISABLE_FAST_FLOAT
+
+// ---- fast_float-based float parser (bit-exact with strtod, ~3x faster) ----
+
+namespace detail_fp {
+
+// Case-insensitive prefix match. Returns pointer past matched prefix, or NULL.
+static inline const char *match_iprefix(const char *p, const char *end,
+                                        const char *prefix) {
+  while (*prefix) {
+    if (p == end) return NULL;
+    char c = *p;
+    char e = *prefix;
+    if (c >= 'A' && c <= 'Z') c += 32;
+    if (e >= 'A' && e <= 'Z') e += 32;
+    if (c != e) return NULL;
+    ++p;
+    ++prefix;
+  }
+  return p;
+}
+
+// Try to parse nan/inf. Returns true if matched, sets *result and *end_ptr.
+static inline bool tryParseNanInf(const char *first, const char *last,
+                                  double *result, const char **end_ptr) {
+  if (first >= last) return false;
+
+  const char *p = first;
+  bool negative = false;
+
+  if (*p == '-') {
+    negative = true;
+    ++p;
+  } else if (*p == '+') {
+    ++p;
+  }
+
+  if (p >= last) return false;
+
+  // Try "nan"
+  const char *after = match_iprefix(p, last, "nan");
+  if (after) {
+    *result = 0.0;  // nan -> 0.0 for OBJ
+    *end_ptr = after;
+    return true;
+  }
+
+  // Try "infinity" first (longer match), then "inf"
+  after = match_iprefix(p, last, "infinity");
+  if (after) {
+    *result = negative ? std::numeric_limits<double>::lowest()
+                       : (std::numeric_limits<double>::max)();
+    *end_ptr = after;
+    return true;
+  }
+
+  after = match_iprefix(p, last, "inf");
+  if (after) {
+    *result = negative ? std::numeric_limits<double>::lowest()
+                       : (std::numeric_limits<double>::max)();
+    *end_ptr = after;
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace detail_fp
+
+// Tries to parse a floating point number located at s.
+// Uses fast_float::from_chars for bit-exact, high-performance parsing.
+// Handles OBJ quirks: leading '+', nan/inf with replacement values.
+//
+// s_end should be a location in the string where reading should absolutely
+// stop. For example at the end of the string, to prevent buffer overflows.
+//
+// If the parsing is a success, result is set to the parsed value and true
+// is returned.
+//
+static bool tryParseDouble(const char *s, const char *s_end, double *result) {
+  if (!s || !s_end || !result || s >= s_end) {
+    return false;
+  }
+
+  // Check for nan/inf (starts with [nNiI] or [+-] followed by [nNiI])
+  const char *p = s;
+  if (p < s_end && (*p == '+' || *p == '-')) ++p;
+  if (p < s_end) {
+    char fc = *p;
+    if (fc >= 'A' && fc <= 'Z') fc += 32;
+    if (fc == 'n' || fc == 'i') {
+      const char *end_ptr;
+      if (detail_fp::tryParseNanInf(s, s_end, result, &end_ptr)) {
+        return true;
+      }
+    }
+  }
+
+  // Use allow_leading_plus so fast_float handles '+' natively.
+  double tmp;
+  auto r = fast_float::from_chars(s, s_end, tmp,
+      fast_float::chars_format::general |
+      fast_float::chars_format::allow_leading_plus);
+  if (r.ec == tinyobj_ff::ff_errc::ok) {
+    *result = tmp;
+    return true;
+  }
+  // On error (invalid_argument, result_out_of_range), *result is unchanged.
+
+  return false;
+}
+
+static inline real_t parseReal(const char **token, double default_value = 0.0) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  double val = default_value;
+  tryParseDouble((*token), end, &val);
+  real_t f = static_cast<real_t>(val);
+  (*token) = end;
+  return f;
+}
+
+static inline bool parseReal(const char **token, real_t *out) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  double val;
+  bool ret = tryParseDouble((*token), end, &val);
+  if (ret) {
+    real_t f = static_cast<real_t>(val);
+    (*out) = f;
+  }
+  (*token) = end;
+  return ret;
+}
+
+#else  // TINYOBJLOADER_DISABLE_FAST_FLOAT
+
+// ---- Legacy hand-written float parser (fallback) ----
+
+// Tries to parse a floating point number located at s.
+//
+// s_end should be a location in the string where reading should absolutely
+// stop. For example at the end of the string, to prevent buffer overflows.
+//
+// Parses the following EBNF grammar:
+//   sign    = "+" | "-" ;
+//   END     = ? anything not in digit ?
+//   digit   = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+//   integer = [sign] , digit , {digit} ;
+//   decimal = integer , ["." , integer] ;
+//   float   = ( decimal , END ) | ( decimal , ("E" | "e") , integer , END ) ;
+//
+//  Valid strings are for example:
+//   -0  +3.1417e+2  -0.0E-3  1.0324  -1.41   11e2
+//
+// If the parsing is a success, result is set to the parsed value and true
+// is returned.
+//
+// The function is greedy and will parse until any of the following happens:
+//  - a non-conforming character is encountered.
+//  - s_end is reached.
+//
+// The following situations triggers a failure:
+//  - s >= s_end.
+//  - parse failure.
+//
+static bool tryParseDouble(const char *s, const char *s_end, double *result) {
+  if (s >= s_end) {
+    return false;
+  }
+
+  double mantissa = 0.0;
+  // This exponent is base 2 rather than 10.
+  // However the exponent we parse is supposed to be one of ten,
+  // thus we must take care to convert the exponent/and or the
+  // mantissa to a * 2^E, where a is the mantissa and E is the
+  // exponent.
+  // To get the final double we will use ldexp, it requires the
+  // exponent to be in base 2.
+  int exponent = 0;
+
+  // NOTE: THESE MUST BE DECLARED HERE SINCE WE ARE NOT ALLOWED
+  // TO JUMP OVER DEFINITIONS.
+  char sign = '+';
+  char exp_sign = '+';
+  char const *curr = s;
+
+  // How many characters were read in a loop.
+  int read = 0;
+  // Tells whether a loop terminated due to reaching s_end.
+  bool end_not_reached = false;
+  bool leading_decimal_dots = false;
+
+  /*
+          BEGIN PARSING.
+  */
+
+  // Find out what sign we've got.
+  if (*curr == '+' || *curr == '-') {
+    sign = *curr;
+    curr++;
+    if ((curr != s_end) && (*curr == '.')) {
+      // accept. Somethig like `.7e+2`, `-.5234`
+      leading_decimal_dots = true;
+    }
+  } else if (IS_DIGIT(*curr)) { /* Pass through. */
+  } else if (*curr == '.') {
+    // accept. Somethig like `.7e+2`, `-.5234`
+    leading_decimal_dots = true;
+  } else {
+    goto fail;
+  }
+
+  // Read the integer part.
+  end_not_reached = (curr != s_end);
+  if (!leading_decimal_dots) {
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      mantissa *= 10;
+      mantissa += static_cast<int>(*curr - 0x30);
+      curr++;
+      read++;
+      end_not_reached = (curr != s_end);
+    }
+
+    // We must make sure we actually got something.
+    if (read == 0) goto fail;
+  }
+
+  // We allow numbers of form "#", "###" etc.
+  if (!end_not_reached) goto assemble;
+
+  // Read the decimal part.
+  if (*curr == '.') {
+    curr++;
+    read = 1;
+    end_not_reached = (curr != s_end);
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      static const double pow_lut[] = {
+          1.0, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001, 0.0000001,
+      };
+      const int lut_entries = sizeof pow_lut / sizeof pow_lut[0];
+
+      // NOTE: Don't use powf here, it will absolutely murder precision.
+      mantissa += static_cast<int>(*curr - 0x30) *
+                  (read < lut_entries ? pow_lut[read] : std::pow(10.0, -read));
+      read++;
+      curr++;
+      end_not_reached = (curr != s_end);
+    }
+  } else if (*curr == 'e' || *curr == 'E') {
+  } else {
+    goto assemble;
+  }
+
+  if (!end_not_reached) goto assemble;
+
+  // Read the exponent part.
+  if (*curr == 'e' || *curr == 'E') {
+    curr++;
+    // Figure out if a sign is present and if it is.
+    end_not_reached = (curr != s_end);
+    if (end_not_reached && (*curr == '+' || *curr == '-')) {
+      exp_sign = *curr;
+      curr++;
+    } else if (IS_DIGIT(*curr)) { /* Pass through. */
+    } else {
+      // Empty E is not allowed.
+      goto fail;
+    }
+
+    read = 0;
+    end_not_reached = (curr != s_end);
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      // To avoid annoying MSVC's min/max macro definiton,
+      // Use hardcoded int max value
+      if (exponent >
+          ((2147483647 - 9) / 10)) {  // (INT_MAX - 9) / 10, guards both multiply and add
+        // Integer overflow
+        goto fail;
+      }
+      exponent *= 10;
+      exponent += static_cast<int>(*curr - 0x30);
+      curr++;
+      read++;
+      end_not_reached = (curr != s_end);
+    }
+    exponent *= (exp_sign == '+' ? 1 : -1);
+    if (read == 0) goto fail;
+  }
+
+assemble:
+  *result = (sign == '+' ? 1 : -1) *
+            (exponent ? std::ldexp(mantissa * std::pow(5.0, exponent), exponent)
+                      : mantissa);
+  return true;
+fail:
+  return false;
+}
+
+static inline real_t parseReal(const char **token, double default_value = 0.0) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  double val = default_value;
+  tryParseDouble((*token), end, &val);
+  real_t f = static_cast<real_t>(val);
+  (*token) = end;
+  return f;
+}
+
+static inline bool parseReal(const char **token, real_t *out) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  double val;
+  bool ret = tryParseDouble((*token), end, &val);
+  if (ret) {
+    real_t f = static_cast<real_t>(val);
+    (*out) = f;
+  }
+  (*token) = end;
+  return ret;
+}
+
+#endif  // TINYOBJLOADER_DISABLE_FAST_FLOAT
+
+static inline void parseReal2(real_t *x, real_t *y, const char **token,
+                              const double default_x = 0.0,
+                              const double default_y = 0.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+}
+
+static inline void parseReal3(real_t *x, real_t *y, real_t *z,
+                              const char **token, const double default_x = 0.0,
+                              const double default_y = 0.0,
+                              const double default_z = 0.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+}
+
+#if 0  // not used
+static inline void parseV(real_t *x, real_t *y, real_t *z, real_t *w,
+                          const char **token, const double default_x = 0.0,
+                          const double default_y = 0.0,
+                          const double default_z = 0.0,
+                          const double default_w = 1.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+  (*w) = parseReal(token, default_w);
+}
+#endif
+
+// Extension: parse vertex with colors(6 items)
+// Return 3: xyz, 4: xyzw, 6: xyzrgb
+// `r`: red(case 6) or [w](case 4)
+static inline int parseVertexWithColor(real_t *x, real_t *y, real_t *z,
+                                       real_t *r, real_t *g, real_t *b,
+                                       const char **token,
+                                       const double default_x = 0.0,
+                                       const double default_y = 0.0,
+                                       const double default_z = 0.0) {
+  // TODO: Check error
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+
+  // - 4 components(x, y, z, w) ot 6 components
+  bool has_r = parseReal(token, r);
+
+  if (!has_r) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;
+  }
+
+  bool has_g = parseReal(token, g);
+
+  if (!has_g) {
+    (*g) = (*b) = 1.0;
+    return 4;
+  }
+
+  bool has_b = parseReal(token, b);
+
+  if (!has_b) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;  // treated as xyz
+  }
+
+  return 6;
+}
+
+static inline bool parseOnOff(const char **token, bool default_value = true) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+
+  bool ret = default_value;
+  if ((0 == strncmp((*token), "on", 2))) {
+    ret = true;
+  } else if ((0 == strncmp((*token), "off", 3))) {
+    ret = false;
+  }
+
+  (*token) = end;
+  return ret;
+}
+
+static inline texture_type_t parseTextureType(
+    const char **token, texture_type_t default_value = TEXTURE_TYPE_NONE) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  texture_type_t ty = default_value;
+
+  if ((0 == strncmp((*token), "cube_top", strlen("cube_top")))) {
+    ty = TEXTURE_TYPE_CUBE_TOP;
+  } else if ((0 == strncmp((*token), "cube_bottom", strlen("cube_bottom")))) {
+    ty = TEXTURE_TYPE_CUBE_BOTTOM;
+  } else if ((0 == strncmp((*token), "cube_left", strlen("cube_left")))) {
+    ty = TEXTURE_TYPE_CUBE_LEFT;
+  } else if ((0 == strncmp((*token), "cube_right", strlen("cube_right")))) {
+    ty = TEXTURE_TYPE_CUBE_RIGHT;
+  } else if ((0 == strncmp((*token), "cube_front", strlen("cube_front")))) {
+    ty = TEXTURE_TYPE_CUBE_FRONT;
+  } else if ((0 == strncmp((*token), "cube_back", strlen("cube_back")))) {
+    ty = TEXTURE_TYPE_CUBE_BACK;
+  } else if ((0 == strncmp((*token), "sphere", strlen("sphere")))) {
+    ty = TEXTURE_TYPE_SPHERE;
+  }
+
+  (*token) = end;
+  return ty;
+}
+
+static tag_sizes parseTagTriple(const char **token) {
+  tag_sizes ts;
+
+  (*token) += strspn((*token), " \t");
+  ts.num_ints = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return ts;
+  }
+
+  (*token)++;  // Skip '/'
+
+  (*token) += strspn((*token), " \t");
+  ts.num_reals = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return ts;
+  }
+  (*token)++;  // Skip '/'
+
+  ts.num_strings = parseInt(token);
+
+  return ts;
+}
+
+// Parse triples with index offsets: i, i/j/k, i//k, i/j
+static bool parseTriple(const char **token, int vsize, int vnsize, int vtsize,
+                        vertex_index_t *ret, const warning_context &context) {
+  if (!ret) {
+    return false;
+  }
+
+  vertex_index_t vi(-1);
+
+  if (!fixIndex(atoi((*token)), vsize, &vi.v_idx, false, context)) {
+    return false;
+  }
+
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    (*ret) = vi;
+    return true;
+  }
+  (*token)++;
+
+  // i//k
+  if ((*token)[0] == '/') {
+    (*token)++;
+    if (!fixIndex(atoi((*token)), vnsize, &vi.vn_idx, true, context)) {
+      return false;
+    }
+    (*token) += strcspn((*token), "/ \t\r");
+    (*ret) = vi;
+    return true;
+  }
+
+  // i/j/k or i/j
+  if (!fixIndex(atoi((*token)), vtsize, &vi.vt_idx, true, context)) {
+    return false;
+  }
+
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    (*ret) = vi;
+    return true;
+  }
+
+  // i/j/k
+  (*token)++;  // skip '/'
+  if (!fixIndex(atoi((*token)), vnsize, &vi.vn_idx, true, context)) {
+    return false;
+  }
+  (*token) += strcspn((*token), "/ \t\r");
+
+  (*ret) = vi;
+
+  return true;
+}
+
+// Parse raw triples: i, i/j/k, i//k, i/j
+static vertex_index_t parseRawTriple(const char **token) {
+  vertex_index_t vi(static_cast<int>(0));  // 0 is an invalid index in OBJ
+
+  vi.v_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+  (*token)++;
+
+  // i//k
+  if ((*token)[0] == '/') {
+    (*token)++;
+    vi.vn_idx = atoi((*token));
+    (*token) += strcspn((*token), "/ \t\r");
+    return vi;
+  }
+
+  // i/j/k or i/j
+  vi.vt_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+
+  // i/j/k
+  (*token)++;  // skip '/'
+  vi.vn_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  return vi;
+}
+
+// --- Stream-based parse functions ---
+
+static inline std::string sr_parseString(StreamReader &sr) {
+  sr.skip_space();
+  std::string s;
+  while (!sr.eof()) {
+    char c = sr.peek();
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\0') break;
+    s += c;
+    sr.advance(1);
+  }
+  return s;
+}
+
+static inline int sr_parseInt(StreamReader &sr) {
+  sr.skip_space();
+  const char *start = sr.current_ptr();
+  size_t rem = sr.remaining();
+  size_t len = 0;
+  while (len < rem) {
+    char c = start[len];
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\0') break;
+    len++;
+  }
+  int i = 0;
+  if (len > 0) {
+    char tmp[64];
+    size_t copy_len = len < 63 ? len : 63;
+    if (copy_len != len) {
+      sr.advance(len);
+      return 0;
+    }
+    memcpy(tmp, start, copy_len);
+    tmp[copy_len] = '\0';
+    errno = 0;
+    char *endptr = NULL;
+    long val = strtol(tmp, &endptr, 10);
+    const bool has_error =
+        (errno == ERANGE || endptr == tmp ||
+         val > (std::numeric_limits<int>::max)() ||
+         val < (std::numeric_limits<int>::min)());
+    if (!has_error) {
+      i = static_cast<int>(val);
+    }
+  }
+  sr.advance(len);
+  return i;
+}
+
+static inline real_t sr_parseReal(StreamReader &sr, double default_value = 0.0) {
+  sr.skip_space();
+  const char *start = sr.current_ptr();
+  size_t rem = sr.remaining();
+  size_t len = 0;
+  while (len < rem) {
+    char c = start[len];
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\0') break;
+    len++;
+  }
+  double val = default_value;
+  if (len > 0) {
+    tryParseDouble(start, start + len, &val);
+  }
+  sr.advance(len);
+  return static_cast<real_t>(val);
+}
+
+static inline bool sr_parseReal(StreamReader &sr, real_t *out) {
+  sr.skip_space();
+  const char *start = sr.current_ptr();
+  size_t rem = sr.remaining();
+  size_t len = 0;
+  while (len < rem) {
+    char c = start[len];
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\0') break;
+    len++;
+  }
+  if (len == 0) return false;
+  double val;
+  bool ret = tryParseDouble(start, start + len, &val);
+  if (ret) {
+    (*out) = static_cast<real_t>(val);
+  }
+  sr.advance(len);
+  return ret;
+}
+
+static inline void sr_parseReal2(real_t *x, real_t *y, StreamReader &sr,
+                                 const double default_x = 0.0,
+                                 const double default_y = 0.0) {
+  (*x) = sr_parseReal(sr, default_x);
+  (*y) = sr_parseReal(sr, default_y);
+}
+
+static inline void sr_parseReal3(real_t *x, real_t *y, real_t *z,
+                                 StreamReader &sr,
+                                 const double default_x = 0.0,
+                                 const double default_y = 0.0,
+                                 const double default_z = 0.0) {
+  (*x) = sr_parseReal(sr, default_x);
+  (*y) = sr_parseReal(sr, default_y);
+  (*z) = sr_parseReal(sr, default_z);
+}
+
+static inline int sr_parseVertexWithColor(real_t *x, real_t *y, real_t *z,
+                                          real_t *r, real_t *g, real_t *b,
+                                          StreamReader &sr,
+                                          const double default_x = 0.0,
+                                          const double default_y = 0.0,
+                                          const double default_z = 0.0) {
+  (*x) = sr_parseReal(sr, default_x);
+  (*y) = sr_parseReal(sr, default_y);
+  (*z) = sr_parseReal(sr, default_z);
+
+  bool has_r = sr_parseReal(sr, r);
+  if (!has_r) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;
+  }
+
+  bool has_g = sr_parseReal(sr, g);
+  if (!has_g) {
+    (*g) = (*b) = 1.0;
+    return 4;
+  }
+
+  bool has_b = sr_parseReal(sr, b);
+  if (!has_b) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;
+  }
+
+  return 6;
+}
+
+// --- Error-reporting overloads ---
+// These overloads push clang-style diagnostics into `err` when parsing fails
+// and return false so callers can early-return on unrecoverable parse errors.
+// The original signatures are preserved above for backward compatibility.
+
+static inline bool sr_parseInt(StreamReader &sr, int *out, std::string *err,
+                               const std::string &filename) {
+  sr.skip_space();
+  const char *start = sr.current_ptr();
+  size_t rem = sr.remaining();
+  size_t len = 0;
+  while (len < rem) {
+    char c = start[len];
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\0') break;
+    len++;
+  }
+  if (len == 0) {
+    if (err) {
+      (*err) += sr.format_error(filename, "expected integer value");
+    }
+    *out = 0;
+    return false;
+  }
+  char tmp[64];
+  size_t copy_len = len < 63 ? len : 63;
+  memcpy(tmp, start, copy_len);
+  tmp[copy_len] = '\0';
+  if (copy_len != len) {
+    if (err) {
+      (*err) += sr.format_error(filename, "integer value too long");
+    }
+    *out = 0;
+    sr.advance(len);
+    return false;
+  }
+  errno = 0;
+  char *endptr = NULL;
+  long val = strtol(tmp, &endptr, 10);
+  if (errno == ERANGE || val > (std::numeric_limits<int>::max)() ||
+      val < (std::numeric_limits<int>::min)()) {
+    if (err) {
+      (*err) += sr.format_error(filename,
+          "integer value out of range, got '" + std::string(tmp) + "'");
+    }
+    *out = 0;
+    sr.advance(len);
+    return false;
+  }
+  if (endptr == tmp || (*endptr != '\0' && *endptr != ' ' && *endptr != '\t')) {
+    if (err) {
+      (*err) += sr.format_error(filename,
+          "expected integer, got '" + std::string(tmp) + "'");
+    }
+    *out = 0;
+    sr.advance(len);
+    return false;
+  }
+  *out = static_cast<int>(val);
+  sr.advance(len);
+  return true;
+}
+
+static inline bool sr_parseReal(StreamReader &sr, real_t *out,
+                                 double default_value,
+                                 std::string *err,
+                                 const std::string &filename) {
+  sr.skip_space();
+  const char *start = sr.current_ptr();
+  size_t rem = sr.remaining();
+  size_t len = 0;
+  while (len < rem) {
+    char c = start[len];
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\0') break;
+    len++;
+  }
+  if (len == 0) {
+    // No token to parse — not necessarily an error (e.g. optional component).
+    *out = static_cast<real_t>(default_value);
+    return true;
+  }
+  double val;
+  if (!tryParseDouble(start, start + len, &val)) {
+    if (err) {
+      char tmp[64];
+      size_t copy_len = len < 63 ? len : 63;
+      memcpy(tmp, start, copy_len);
+      tmp[copy_len] = '\0';
+      (*err) += sr.format_error(filename,
+          "expected number, got '" + std::string(tmp) + "'");
+    }
+    *out = static_cast<real_t>(default_value);
+    sr.advance(len);
+    return false;
+  }
+  *out = static_cast<real_t>(val);
+  sr.advance(len);
+  return true;
+}
+
+static inline bool sr_parseReal2(real_t *x, real_t *y, StreamReader &sr,
+                                  std::string *err,
+                                  const std::string &filename,
+                                  const double default_x = 0.0,
+                                  const double default_y = 0.0) {
+  if (!sr_parseReal(sr, x, default_x, err, filename)) return false;
+  if (!sr_parseReal(sr, y, default_y, err, filename)) return false;
+  return true;
+}
+
+static inline bool sr_parseReal3(real_t *x, real_t *y, real_t *z,
+                                  StreamReader &sr,
+                                  std::string *err,
+                                  const std::string &filename,
+                                  const double default_x = 0.0,
+                                  const double default_y = 0.0,
+                                  const double default_z = 0.0) {
+  if (!sr_parseReal(sr, x, default_x, err, filename)) return false;
+  if (!sr_parseReal(sr, y, default_y, err, filename)) return false;
+  if (!sr_parseReal(sr, z, default_z, err, filename)) return false;
+  return true;
+}
+
+// Returns number of components parsed (3, 4, or 6) on success, -1 on error.
+static inline int sr_parseVertexWithColor(real_t *x, real_t *y, real_t *z,
+                                          real_t *r, real_t *g, real_t *b,
+                                          StreamReader &sr,
+                                          std::string *err,
+                                          const std::string &filename,
+                                          const double default_x = 0.0,
+                                          const double default_y = 0.0,
+                                          const double default_z = 0.0) {
+  if (!sr_parseReal(sr, x, default_x, err, filename)) return -1;
+  if (!sr_parseReal(sr, y, default_y, err, filename)) return -1;
+  if (!sr_parseReal(sr, z, default_z, err, filename)) return -1;
+
+  bool has_r = sr_parseReal(sr, r);
+  if (!has_r) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;
+  }
+
+  bool has_g = sr_parseReal(sr, g);
+  if (!has_g) {
+    (*g) = (*b) = 1.0;
+    return 4;
+  }
+
+  bool has_b = sr_parseReal(sr, b);
+  if (!has_b) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;
+  }
+
+  return 6;
+}
+
+static inline int sr_parseIntNoSkip(StreamReader &sr);
+
+// Advance past remaining characters in a tag triple field (stops at '/', whitespace, or line end).
+static inline void sr_skipTagField(StreamReader &sr) {
+  while (!sr.eof() && !sr.at_line_end() && !IS_SPACE(sr.peek()) &&
+         sr.peek() != '/') {
+    sr.advance(1);
+  }
+}
+
+static tag_sizes sr_parseTagTriple(StreamReader &sr) {
+  tag_sizes ts;
+
+  sr.skip_space();
+  ts.num_ints = sr_parseIntNoSkip(sr);
+  sr_skipTagField(sr);
+  if (!sr.eof() && sr.peek() == '/') {
+    sr.advance(1);
+    sr.skip_space();
+    ts.num_reals = sr_parseIntNoSkip(sr);
+    sr_skipTagField(sr);
+    if (!sr.eof() && sr.peek() == '/') {
+      sr.advance(1);
+      ts.num_strings = sr_parseInt(sr);
+    }
+  }
+  return ts;
+}
+
+static inline int sr_parseIntNoSkip(StreamReader &sr) {
+  const char *start = sr.current_ptr();
+  size_t rem = sr.remaining();
+  size_t len = 0;
+  if (len < rem && (start[len] == '+' || start[len] == '-')) len++;
+  while (len < rem && start[len] >= '0' && start[len] <= '9') len++;
+  int i = 0;
+  if (len > 0) {
+    char tmp[64];
+    size_t copy_len = len < 63 ? len : 63;
+    if (copy_len != len) {
+      sr.advance(len);
+      return 0;
+    }
+    memcpy(tmp, start, copy_len);
+    tmp[copy_len] = '\0';
+    errno = 0;
+    char *endptr = NULL;
+    long val = strtol(tmp, &endptr, 10);
+    if (errno == 0 && endptr != tmp && *endptr == '\0' &&
+        val <= (std::numeric_limits<int>::max)() &&
+        val >= (std::numeric_limits<int>::min)()) {
+      i = static_cast<int>(val);
+    }
+  }
+  sr.advance(len);
+  return i;
+}
+
+static inline void sr_skipUntil(StreamReader &sr, const char *delims) {
+  while (!sr.eof()) {
+    char c = sr.peek();
+    for (const char *d = delims; *d; d++) {
+      if (c == *d) return;
+    }
+    sr.advance(1);
+  }
+}
+
+static bool sr_parseTriple(StreamReader &sr, int vsize, int vnsize, int vtsize,
+                           vertex_index_t *ret, const warning_context &context) {
+  if (!ret) return false;
+
+  vertex_index_t vi(-1);
+
+  sr.skip_space();
+  if (!fixIndex(sr_parseIntNoSkip(sr), vsize, &vi.v_idx, false, context)) {
+    return false;
+  }
+
+  sr_skipUntil(sr, "/ \t\r\n");
+  if (sr.eof() || sr.peek() != '/') {
+    (*ret) = vi;
+    return true;
+  }
+  sr.advance(1);
+
+  // i//k
+  if (!sr.eof() && sr.peek() == '/') {
+    sr.advance(1);
+    if (!fixIndex(sr_parseIntNoSkip(sr), vnsize, &vi.vn_idx, true, context)) {
+      return false;
+    }
+    sr_skipUntil(sr, "/ \t\r\n");
+    (*ret) = vi;
+    return true;
+  }
+
+  // i/j/k or i/j
+  if (!fixIndex(sr_parseIntNoSkip(sr), vtsize, &vi.vt_idx, true, context)) {
+    return false;
+  }
+
+  sr_skipUntil(sr, "/ \t\r\n");
+  if (sr.eof() || sr.peek() != '/') {
+    (*ret) = vi;
+    return true;
+  }
+
+  // i/j/k
+  sr.advance(1);
+  if (!fixIndex(sr_parseIntNoSkip(sr), vnsize, &vi.vn_idx, true, context)) {
+    return false;
+  }
+  sr_skipUntil(sr, "/ \t\r\n");
+
+  (*ret) = vi;
+  return true;
+}
+
+static vertex_index_t sr_parseRawTriple(StreamReader &sr) {
+  vertex_index_t vi(static_cast<int>(0));
+
+  sr.skip_space();
+  vi.v_idx = sr_parseIntNoSkip(sr);
+  sr_skipUntil(sr, "/ \t\r\n");
+  if (sr.eof() || sr.peek() != '/') return vi;
+  sr.advance(1);
+
+  // i//k
+  if (!sr.eof() && sr.peek() == '/') {
+    sr.advance(1);
+    vi.vn_idx = sr_parseIntNoSkip(sr);
+    sr_skipUntil(sr, "/ \t\r\n");
+    return vi;
+  }
+
+  // i/j/k or i/j
+  vi.vt_idx = sr_parseIntNoSkip(sr);
+  sr_skipUntil(sr, "/ \t\r\n");
+  if (sr.eof() || sr.peek() != '/') return vi;
+
+  sr.advance(1);
+  vi.vn_idx = sr_parseIntNoSkip(sr);
+  sr_skipUntil(sr, "/ \t\r\n");
+  return vi;
+}
+
+bool ParseTextureNameAndOption(std::string *texname, texture_option_t *texopt,
+                               const char *linebuf) {
+  // @todo { write more robust lexer and parser. }
+  bool found_texname = false;
+  std::string texture_name;
+
+  const char *token = linebuf;  // Assume line ends with NULL
+
+  while (!IS_NEW_LINE((*token))) {
+    token += strspn(token, " \t");  // skip space
+    if ((0 == strncmp(token, "-blendu", 7)) && IS_SPACE((token[7]))) {
+      token += 8;
+      texopt->blendu = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-blendv", 7)) && IS_SPACE((token[7]))) {
+      token += 8;
+      texopt->blendv = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-clamp", 6)) && IS_SPACE((token[6]))) {
+      token += 7;
+      texopt->clamp = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-boost", 6)) && IS_SPACE((token[6]))) {
+      token += 7;
+      texopt->sharpness = parseReal(&token, 1.0);
+    } else if ((0 == strncmp(token, "-bm", 3)) && IS_SPACE((token[3]))) {
+      token += 4;
+      texopt->bump_multiplier = parseReal(&token, 1.0);
+    } else if ((0 == strncmp(token, "-o", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->origin_offset[0]), &(texopt->origin_offset[1]),
+                 &(texopt->origin_offset[2]), &token);
+    } else if ((0 == strncmp(token, "-s", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->scale[0]), &(texopt->scale[1]), &(texopt->scale[2]),
+                 &token, 1.0, 1.0, 1.0);
+    } else if ((0 == strncmp(token, "-t", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->turbulence[0]), &(texopt->turbulence[1]),
+                 &(texopt->turbulence[2]), &token);
+    } else if ((0 == strncmp(token, "-type", 5)) && IS_SPACE((token[5]))) {
+      token += 5;
+      texopt->type = parseTextureType((&token), TEXTURE_TYPE_NONE);
+    } else if ((0 == strncmp(token, "-texres", 7)) && IS_SPACE((token[7]))) {
+      token += 7;
+      // TODO(syoyo): Check if arg is int type.
+      texopt->texture_resolution = parseInt(&token);
+    } else if ((0 == strncmp(token, "-imfchan", 8)) && IS_SPACE((token[8]))) {
+      token += 9;
+      token += strspn(token, " \t");
+      const char *end = token + strcspn(token, " \t\r");
+      if ((end - token) == 1) {  // Assume one char for -imfchan
+        texopt->imfchan = (*token);
+      }
+      token = end;
+    } else if ((0 == strncmp(token, "-mm", 3)) && IS_SPACE((token[3]))) {
+      token += 4;
+      parseReal2(&(texopt->brightness), &(texopt->contrast), &token, 0.0, 1.0);
+    } else if ((0 == strncmp(token, "-colorspace", 11)) &&
+               IS_SPACE((token[11]))) {
+      token += 12;
+      texopt->colorspace = parseString(&token);
+    } else {
+// Assume texture filename
+#if 0
+      size_t len = strcspn(token, " \t\r");  // untile next space
+      texture_name = std::string(token, token + len);
+      token += len;
+
+      token += strspn(token, " \t");  // skip space
+#else
+      // Read filename until line end to parse filename containing whitespace
+      // TODO(syoyo): Support parsing texture option flag after the filename.
+      texture_name = std::string(token);
+      token += texture_name.length();
+#endif
+
+      found_texname = true;
+    }
+  }
+
+  if (found_texname) {
+    (*texname) = texture_name;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static void InitTexOpt(texture_option_t *texopt, const bool is_bump) {
+  if (is_bump) {
+    texopt->imfchan = 'l';
+  } else {
+    texopt->imfchan = 'm';
+  }
+  texopt->bump_multiplier = static_cast<real_t>(1.0);
+  texopt->clamp = false;
+  texopt->blendu = true;
+  texopt->blendv = true;
+  texopt->sharpness = static_cast<real_t>(1.0);
+  texopt->brightness = static_cast<real_t>(0.0);
+  texopt->contrast = static_cast<real_t>(1.0);
+  texopt->origin_offset[0] = static_cast<real_t>(0.0);
+  texopt->origin_offset[1] = static_cast<real_t>(0.0);
+  texopt->origin_offset[2] = static_cast<real_t>(0.0);
+  texopt->scale[0] = static_cast<real_t>(1.0);
+  texopt->scale[1] = static_cast<real_t>(1.0);
+  texopt->scale[2] = static_cast<real_t>(1.0);
+  texopt->turbulence[0] = static_cast<real_t>(0.0);
+  texopt->turbulence[1] = static_cast<real_t>(0.0);
+  texopt->turbulence[2] = static_cast<real_t>(0.0);
+  texopt->texture_resolution = -1;
+  texopt->type = TEXTURE_TYPE_NONE;
+}
+
+static void InitMaterial(material_t *material) {
+  InitTexOpt(&material->ambient_texopt, /* is_bump */ false);
+  InitTexOpt(&material->diffuse_texopt, /* is_bump */ false);
+  InitTexOpt(&material->specular_texopt, /* is_bump */ false);
+  InitTexOpt(&material->specular_highlight_texopt, /* is_bump */ false);
+  InitTexOpt(&material->bump_texopt, /* is_bump */ true);
+  InitTexOpt(&material->displacement_texopt, /* is_bump */ false);
+  InitTexOpt(&material->alpha_texopt, /* is_bump */ false);
+  InitTexOpt(&material->reflection_texopt, /* is_bump */ false);
+  InitTexOpt(&material->roughness_texopt, /* is_bump */ false);
+  InitTexOpt(&material->metallic_texopt, /* is_bump */ false);
+  InitTexOpt(&material->sheen_texopt, /* is_bump */ false);
+  InitTexOpt(&material->emissive_texopt, /* is_bump */ false);
+  InitTexOpt(&material->normal_texopt,
+             /* is_bump */ false);  // @fixme { is_bump will be true? }
+  material->name = "";
+  material->ambient_texname = "";
+  material->diffuse_texname = "";
+  material->specular_texname = "";
+  material->specular_highlight_texname = "";
+  material->bump_texname = "";
+  material->displacement_texname = "";
+  material->reflection_texname = "";
+  material->alpha_texname = "";
+  for (int i = 0; i < 3; i++) {
+    material->ambient[i] = static_cast<real_t>(0.0);
+    material->diffuse[i] = static_cast<real_t>(0.0);
+    material->specular[i] = static_cast<real_t>(0.0);
+    material->transmittance[i] = static_cast<real_t>(0.0);
+    material->emission[i] = static_cast<real_t>(0.0);
+  }
+  material->illum = 0;
+  material->dissolve = static_cast<real_t>(1.0);
+  material->shininess = static_cast<real_t>(1.0);
+  material->ior = static_cast<real_t>(1.0);
+
+  material->roughness = static_cast<real_t>(0.0);
+  material->metallic = static_cast<real_t>(0.0);
+  material->sheen = static_cast<real_t>(0.0);
+  material->clearcoat_thickness = static_cast<real_t>(0.0);
+  material->clearcoat_roughness = static_cast<real_t>(0.0);
+  material->anisotropy_rotation = static_cast<real_t>(0.0);
+  material->anisotropy = static_cast<real_t>(0.0);
+  material->roughness_texname = "";
+  material->metallic_texname = "";
+  material->sheen_texname = "";
+  material->emissive_texname = "";
+  material->normal_texname = "";
+
+  material->unknown_parameter.clear();
+}
+
+// code from https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
+template <typename T>
+static int pnpoly(int nvert, T *vertx, T *verty, T testx, T testy) {
+  int i, j, c = 0;
+  for (i = 0, j = nvert - 1; i < nvert; j = i++) {
+    if (((verty[i] > testy) != (verty[j] > testy)) &&
+        (testx <
+         (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) +
+             vertx[i]))
+      c = !c;
+  }
+  return c;
+}
+
+struct TinyObjPoint {
+  real_t x, y, z;
+  TinyObjPoint() : x(0), y(0), z(0) {}
+  TinyObjPoint(real_t x_, real_t y_, real_t z_) : x(x_), y(y_), z(z_) {}
+};
+
+inline TinyObjPoint cross(const TinyObjPoint &v1, const TinyObjPoint &v2) {
+  return TinyObjPoint(v1.y * v2.z - v1.z * v2.y, v1.z * v2.x - v1.x * v2.z,
+                      v1.x * v2.y - v1.y * v2.x);
+}
+
+inline real_t dot(const TinyObjPoint &v1, const TinyObjPoint &v2) {
+  return (v1.x * v2.x + v1.y * v2.y + v1.z * v2.z);
+}
+
+inline real_t GetLength(TinyObjPoint &e) {
+  return std::sqrt(e.x * e.x + e.y * e.y + e.z * e.z);
+}
+
+inline TinyObjPoint Normalize(TinyObjPoint e) {
+  real_t len = GetLength(e);
+  if (len <= real_t(0)) return TinyObjPoint(real_t(0), real_t(0), real_t(0));
+  real_t inv_length = real_t(1) / len;
+  return TinyObjPoint(e.x * inv_length, e.y * inv_length, e.z * inv_length);
+}
+
+inline TinyObjPoint WorldToLocal(const TinyObjPoint &a, const TinyObjPoint &u,
+                                 const TinyObjPoint &v, const TinyObjPoint &w) {
+  return TinyObjPoint(dot(a, u), dot(a, v), dot(a, w));
+}
+
+// TODO(syoyo): refactor function.
+static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
+                                const std::vector<tag_t> &tags,
+                                const int material_id, const std::string &name,
+                                bool triangulate, const std::vector<real_t> &v,
+                                std::string *warn) {
+  if (prim_group.IsEmpty()) {
+    return false;
+  }
+
+  shape->name = name;
+
+  // polygon
+  if (!prim_group.faceGroup.empty()) {
+    // Flatten vertices and indices
+    for (size_t i = 0; i < prim_group.faceGroup.size(); i++) {
+      const face_t &face = prim_group.faceGroup[i];
+
+      size_t npolys = face.vertex_indices.size();
+
+      if (npolys < 3) {
+        // Face must have 3+ vertices.
+        if (warn) {
+          (*warn) += "Degenerated face found\n.";
+        }
+        continue;
+      }
+
+      if (triangulate && npolys != 3) {
+        if (npolys == 4) {
+          vertex_index_t i0 = face.vertex_indices[0];
+          vertex_index_t i1 = face.vertex_indices[1];
+          vertex_index_t i2 = face.vertex_indices[2];
+          vertex_index_t i3 = face.vertex_indices[3];
+
+          if (i0.v_idx < 0 || i1.v_idx < 0 || i2.v_idx < 0 || i3.v_idx < 0) {
+            if (warn) {
+              (*warn) += "Face with invalid vertex index found.\n";
+            }
+            continue;
+          }
+
+          size_t vi0 = size_t(i0.v_idx);
+          size_t vi1 = size_t(i1.v_idx);
+          size_t vi2 = size_t(i2.v_idx);
+          size_t vi3 = size_t(i3.v_idx);
+
+          if (((3 * vi0 + 2) >= v.size()) || ((3 * vi1 + 2) >= v.size()) ||
+              ((3 * vi2 + 2) >= v.size()) || ((3 * vi3 + 2) >= v.size())) {
+            // Invalid triangle.
+            // FIXME(syoyo): Is it ok to simply skip this invalid triangle?
+            if (warn) {
+              (*warn) += "Face with invalid vertex index found.\n";
+            }
+            continue;
+          }
+
+          real_t v0x = v[vi0 * 3 + 0];
+          real_t v0y = v[vi0 * 3 + 1];
+          real_t v0z = v[vi0 * 3 + 2];
+          real_t v1x = v[vi1 * 3 + 0];
+          real_t v1y = v[vi1 * 3 + 1];
+          real_t v1z = v[vi1 * 3 + 2];
+          real_t v2x = v[vi2 * 3 + 0];
+          real_t v2y = v[vi2 * 3 + 1];
+          real_t v2z = v[vi2 * 3 + 2];
+          real_t v3x = v[vi3 * 3 + 0];
+          real_t v3y = v[vi3 * 3 + 1];
+          real_t v3z = v[vi3 * 3 + 2];
+
+          // There are two candidates to split the quad into two triangles.
+          //
+          // Choose the shortest edge.
+          // TODO: Is it better to determine the edge to split by calculating
+          // the area of each triangle?
+          //
+          // +---+
+          // |\  |
+          // | \ |
+          // |  \|
+          // +---+
+          //
+          // +---+
+          // |  /|
+          // | / |
+          // |/  |
+          // +---+
+
+          real_t e02x = v2x - v0x;
+          real_t e02y = v2y - v0y;
+          real_t e02z = v2z - v0z;
+          real_t e13x = v3x - v1x;
+          real_t e13y = v3y - v1y;
+          real_t e13z = v3z - v1z;
+
+          real_t sqr02 = e02x * e02x + e02y * e02y + e02z * e02z;
+          real_t sqr13 = e13x * e13x + e13y * e13y + e13z * e13z;
+
+          index_t idx0, idx1, idx2, idx3;
+
+          idx0.vertex_index = i0.v_idx;
+          idx0.normal_index = i0.vn_idx;
+          idx0.texcoord_index = i0.vt_idx;
+          idx1.vertex_index = i1.v_idx;
+          idx1.normal_index = i1.vn_idx;
+          idx1.texcoord_index = i1.vt_idx;
+          idx2.vertex_index = i2.v_idx;
+          idx2.normal_index = i2.vn_idx;
+          idx2.texcoord_index = i2.vt_idx;
+          idx3.vertex_index = i3.v_idx;
+          idx3.normal_index = i3.vn_idx;
+          idx3.texcoord_index = i3.vt_idx;
+
+          if (sqr02 < sqr13) {
+            // [0, 1, 2], [0, 2, 3]
+            shape->mesh.indices.push_back(idx0);
+            shape->mesh.indices.push_back(idx1);
+            shape->mesh.indices.push_back(idx2);
+
+            shape->mesh.indices.push_back(idx0);
+            shape->mesh.indices.push_back(idx2);
+            shape->mesh.indices.push_back(idx3);
+          } else {
+            // [0, 1, 3], [1, 2, 3]
+            shape->mesh.indices.push_back(idx0);
+            shape->mesh.indices.push_back(idx1);
+            shape->mesh.indices.push_back(idx3);
+
+            shape->mesh.indices.push_back(idx1);
+            shape->mesh.indices.push_back(idx2);
+            shape->mesh.indices.push_back(idx3);
+          }
+
+          // Two triangle faces
+          shape->mesh.num_face_vertices.push_back(3);
+          shape->mesh.num_face_vertices.push_back(3);
+
+          shape->mesh.material_ids.push_back(material_id);
+          shape->mesh.material_ids.push_back(material_id);
+
+          shape->mesh.smoothing_group_ids.push_back(face.smoothing_group_id);
+          shape->mesh.smoothing_group_ids.push_back(face.smoothing_group_id);
+
+        } else {
+#ifdef TINYOBJLOADER_USE_MAPBOX_EARCUT
+          // Validate all vertex indices before accessing the vertex array.
+          {
+            bool valid_poly = true;
+            for (size_t k = 0; k < npolys; ++k) {
+              size_t vi = size_t(face.vertex_indices[k].v_idx);
+              if ((3 * vi + 2) >= v.size()) {
+                valid_poly = false;
+                break;
+              }
+            }
+            if (!valid_poly) {
+              if (warn) {
+                (*warn) += "Face with invalid vertex index found.\n";
+              }
+              continue;
+            }
+          }
+
+          vertex_index_t i0 = face.vertex_indices[0];
+          vertex_index_t i0_2 = i0;
+
+          // TMW change: Find the normal axis of the polygon using Newell's
+          // method
+          TinyObjPoint n;
+          for (size_t k = 0; k < npolys; ++k) {
+            i0 = face.vertex_indices[k % npolys];
+            size_t vi0 = size_t(i0.v_idx);
+
+            size_t j = (k + 1) % npolys;
+            i0_2 = face.vertex_indices[j];
+            size_t vi0_2 = size_t(i0_2.v_idx);
+
+            real_t v0x = v[vi0 * 3 + 0];
+            real_t v0y = v[vi0 * 3 + 1];
+            real_t v0z = v[vi0 * 3 + 2];
+
+            real_t v0x_2 = v[vi0_2 * 3 + 0];
+            real_t v0y_2 = v[vi0_2 * 3 + 1];
+            real_t v0z_2 = v[vi0_2 * 3 + 2];
+
+            const TinyObjPoint point1(v0x, v0y, v0z);
+            const TinyObjPoint point2(v0x_2, v0y_2, v0z_2);
+
+            TinyObjPoint a(point1.x - point2.x, point1.y - point2.y,
+                           point1.z - point2.z);
+            TinyObjPoint b(point1.x + point2.x, point1.y + point2.y,
+                           point1.z + point2.z);
+
+            n.x += (a.y * b.z);
+            n.y += (a.z * b.x);
+            n.z += (a.x * b.y);
+          }
+          real_t length_n = GetLength(n);
+          // Check if zero length normal
+          if (length_n <= 0) {
+            continue;
+          }
+          // Negative is to flip the normal to the correct direction
+          real_t inv_length = -real_t(1.0) / length_n;
+          n.x *= inv_length;
+          n.y *= inv_length;
+          n.z *= inv_length;
+
+          TinyObjPoint axis_w, axis_v, axis_u;
+          axis_w = n;
+          TinyObjPoint a;
+          if (std::fabs(axis_w.x) > real_t(0.9999999)) {
+            a = TinyObjPoint(0, 1, 0);
+          } else {
+            a = TinyObjPoint(1, 0, 0);
+          }
+          axis_v = Normalize(cross(axis_w, a));
+          axis_u = cross(axis_w, axis_v);
+          using Point = std::array<real_t, 2>;
+
+          // first polyline define the main polygon.
+          // following polylines define holes(not used in tinyobj).
+          std::vector<std::vector<Point> > polygon;
+
+          std::vector<Point> polyline;
+
+          // TMW change: Find best normal and project v0x and v0y to those
+          // coordinates, instead of picking a plane aligned with an axis (which
+          // can flip polygons).
+
+          // Fill polygon data(facevarying vertices).
+          for (size_t k = 0; k < npolys; k++) {
+            i0 = face.vertex_indices[k];
+            size_t vi0 = size_t(i0.v_idx);
+
+            assert(((3 * vi0 + 2) < v.size()));
+
+            real_t v0x = v[vi0 * 3 + 0];
+            real_t v0y = v[vi0 * 3 + 1];
+            real_t v0z = v[vi0 * 3 + 2];
+
+            TinyObjPoint polypoint(v0x, v0y, v0z);
+            TinyObjPoint loc = WorldToLocal(polypoint, axis_u, axis_v, axis_w);
+
+            polyline.push_back({loc.x, loc.y});
+          }
+
+          polygon.push_back(polyline);
+          std::vector<uint32_t> indices = mapbox::earcut<uint32_t>(polygon);
+          // => result = 3 * faces, clockwise
+
+          assert(indices.size() % 3 == 0);
+
+          // Reconstruct vertex_index_t
+          for (size_t k = 0; k < indices.size() / 3; k++) {
+            {
+              index_t idx0, idx1, idx2;
+              idx0.vertex_index = face.vertex_indices[indices[3 * k + 0]].v_idx;
+              idx0.normal_index =
+                  face.vertex_indices[indices[3 * k + 0]].vn_idx;
+              idx0.texcoord_index =
+                  face.vertex_indices[indices[3 * k + 0]].vt_idx;
+              idx1.vertex_index = face.vertex_indices[indices[3 * k + 1]].v_idx;
+              idx1.normal_index =
+                  face.vertex_indices[indices[3 * k + 1]].vn_idx;
+              idx1.texcoord_index =
+                  face.vertex_indices[indices[3 * k + 1]].vt_idx;
+              idx2.vertex_index = face.vertex_indices[indices[3 * k + 2]].v_idx;
+              idx2.normal_index =
+                  face.vertex_indices[indices[3 * k + 2]].vn_idx;
+              idx2.texcoord_index =
+                  face.vertex_indices[indices[3 * k + 2]].vt_idx;
+
+              shape->mesh.indices.push_back(idx0);
+              shape->mesh.indices.push_back(idx1);
+              shape->mesh.indices.push_back(idx2);
+
+              shape->mesh.num_face_vertices.push_back(3);
+              shape->mesh.material_ids.push_back(material_id);
+              shape->mesh.smoothing_group_ids.push_back(
+                  face.smoothing_group_id);
+            }
+          }
+
+#else  // Built-in ear clipping triangulation
+          vertex_index_t i0 = face.vertex_indices[0];
+          vertex_index_t i1(-1);
+          vertex_index_t i2 = face.vertex_indices[1];
+
+          // find the two axes to work in
+          size_t axes[2] = {1, 2};
+          for (size_t k = 0; k < npolys; ++k) {
+            i0 = face.vertex_indices[(k + 0) % npolys];
+            i1 = face.vertex_indices[(k + 1) % npolys];
+            i2 = face.vertex_indices[(k + 2) % npolys];
+            size_t vi0 = size_t(i0.v_idx);
+            size_t vi1 = size_t(i1.v_idx);
+            size_t vi2 = size_t(i2.v_idx);
+
+            if (((3 * vi0 + 2) >= v.size()) || ((3 * vi1 + 2) >= v.size()) ||
+                ((3 * vi2 + 2) >= v.size())) {
+              // Invalid triangle.
+              // FIXME(syoyo): Is it ok to simply skip this invalid triangle?
+              continue;
+            }
+            real_t v0x = v[vi0 * 3 + 0];
+            real_t v0y = v[vi0 * 3 + 1];
+            real_t v0z = v[vi0 * 3 + 2];
+            real_t v1x = v[vi1 * 3 + 0];
+            real_t v1y = v[vi1 * 3 + 1];
+            real_t v1z = v[vi1 * 3 + 2];
+            real_t v2x = v[vi2 * 3 + 0];
+            real_t v2y = v[vi2 * 3 + 1];
+            real_t v2z = v[vi2 * 3 + 2];
+            real_t e0x = v1x - v0x;
+            real_t e0y = v1y - v0y;
+            real_t e0z = v1z - v0z;
+            real_t e1x = v2x - v1x;
+            real_t e1y = v2y - v1y;
+            real_t e1z = v2z - v1z;
+            real_t cx = std::fabs(e0y * e1z - e0z * e1y);
+            real_t cy = std::fabs(e0z * e1x - e0x * e1z);
+            real_t cz = std::fabs(e0x * e1y - e0y * e1x);
+            const real_t epsilon = std::numeric_limits<real_t>::epsilon();
+            // std::cout << "cx " << cx << ", cy " << cy << ", cz " << cz <<
+            // "\n";
+            if (cx > epsilon || cy > epsilon || cz > epsilon) {
+              // std::cout << "corner\n";
+              // found a corner
+              if (cx > cy && cx > cz) {
+                // std::cout << "pattern0\n";
+              } else {
+                // std::cout << "axes[0] = 0\n";
+                axes[0] = 0;
+                if (cz > cx && cz > cy) {
+                  // std::cout << "axes[1] = 1\n";
+                  axes[1] = 1;
+                }
+              }
+              break;
+            }
+          }
+
+          face_t remainingFace = face;  // copy
+          size_t guess_vert = 0;
+          vertex_index_t ind[3];
+          real_t vx[3];
+          real_t vy[3];
+
+          // How many iterations can we do without decreasing the remaining
+          // vertices.
+          size_t remainingIterations = face.vertex_indices.size();
+          size_t previousRemainingVertices =
+              remainingFace.vertex_indices.size();
+
+          while (remainingFace.vertex_indices.size() > 3 &&
+                 remainingIterations > 0) {
+            // std::cout << "remainingIterations " << remainingIterations <<
+            // "\n";
+
+            npolys = remainingFace.vertex_indices.size();
+            if (guess_vert >= npolys) {
+              guess_vert -= npolys;
+            }
+
+            if (previousRemainingVertices != npolys) {
+              // The number of remaining vertices decreased. Reset counters.
+              previousRemainingVertices = npolys;
+              remainingIterations = npolys;
+            } else {
+              // We didn't consume a vertex on previous iteration, reduce the
+              // available iterations.
+              remainingIterations--;
+            }
+
+            for (size_t k = 0; k < 3; k++) {
+              ind[k] = remainingFace.vertex_indices[(guess_vert + k) % npolys];
+              size_t vi = size_t(ind[k].v_idx);
+              if (((vi * 3 + axes[0]) >= v.size()) ||
+                  ((vi * 3 + axes[1]) >= v.size())) {
+                // ???
+                vx[k] = static_cast<real_t>(0.0);
+                vy[k] = static_cast<real_t>(0.0);
+              } else {
+                vx[k] = v[vi * 3 + axes[0]];
+                vy[k] = v[vi * 3 + axes[1]];
+              }
+            }
+
+            //
+            // area is calculated per face
+            //
+            real_t e0x = vx[1] - vx[0];
+            real_t e0y = vy[1] - vy[0];
+            real_t e1x = vx[2] - vx[1];
+            real_t e1y = vy[2] - vy[1];
+            real_t cross = e0x * e1y - e0y * e1x;
+            // std::cout << "axes = " << axes[0] << ", " << axes[1] << "\n";
+            // std::cout << "e0x, e0y, e1x, e1y " << e0x << ", " << e0y << ", "
+            // << e1x << ", " << e1y << "\n";
+
+            real_t area =
+                (vx[0] * vy[1] - vy[0] * vx[1]) * static_cast<real_t>(0.5);
+            // std::cout << "cross " << cross << ", area " << area << "\n";
+            // if an internal angle
+            if (cross * area < static_cast<real_t>(0.0)) {
+              // std::cout << "internal \n";
+              guess_vert += 1;
+              // std::cout << "guess vert : " << guess_vert << "\n";
+              continue;
+            }
+
+            // check all other verts in case they are inside this triangle
+            bool overlap = false;
+            for (size_t otherVert = 3; otherVert < npolys; ++otherVert) {
+              size_t idx = (guess_vert + otherVert) % npolys;
+
+              if (idx >= remainingFace.vertex_indices.size()) {
+                // std::cout << "???0\n";
+                // ???
+                continue;
+              }
+
+              size_t ovi = size_t(remainingFace.vertex_indices[idx].v_idx);
+
+              if (((ovi * 3 + axes[0]) >= v.size()) ||
+                  ((ovi * 3 + axes[1]) >= v.size())) {
+                // std::cout << "???1\n";
+                // ???
+                continue;
+              }
+              real_t tx = v[ovi * 3 + axes[0]];
+              real_t ty = v[ovi * 3 + axes[1]];
+              if (pnpoly(3, vx, vy, tx, ty)) {
+                // std::cout << "overlap\n";
+                overlap = true;
+                break;
+              }
+            }
+
+            if (overlap) {
+              // std::cout << "overlap2\n";
+              guess_vert += 1;
+              continue;
+            }
+
+            // this triangle is an ear
+            {
+              index_t idx0, idx1, idx2;
+              idx0.vertex_index = ind[0].v_idx;
+              idx0.normal_index = ind[0].vn_idx;
+              idx0.texcoord_index = ind[0].vt_idx;
+              idx1.vertex_index = ind[1].v_idx;
+              idx1.normal_index = ind[1].vn_idx;
+              idx1.texcoord_index = ind[1].vt_idx;
+              idx2.vertex_index = ind[2].v_idx;
+              idx2.normal_index = ind[2].vn_idx;
+              idx2.texcoord_index = ind[2].vt_idx;
+
+              shape->mesh.indices.push_back(idx0);
+              shape->mesh.indices.push_back(idx1);
+              shape->mesh.indices.push_back(idx2);
+
+              shape->mesh.num_face_vertices.push_back(3);
+              shape->mesh.material_ids.push_back(material_id);
+              shape->mesh.smoothing_group_ids.push_back(
+                  face.smoothing_group_id);
+            }
+
+            // remove v1 from the list
+            size_t removed_vert_index = (guess_vert + 1) % npolys;
+            while (removed_vert_index + 1 < npolys) {
+              remainingFace.vertex_indices[removed_vert_index] =
+                  remainingFace.vertex_indices[removed_vert_index + 1];
+              removed_vert_index += 1;
+            }
+            remainingFace.vertex_indices.pop_back();
+          }
+
+          // std::cout << "remainingFace.vi.size = " <<
+          // remainingFace.vertex_indices.size() << "\n";
+          if (remainingFace.vertex_indices.size() == 3) {
+            i0 = remainingFace.vertex_indices[0];
+            i1 = remainingFace.vertex_indices[1];
+            i2 = remainingFace.vertex_indices[2];
+            {
+              index_t idx0, idx1, idx2;
+              idx0.vertex_index = i0.v_idx;
+              idx0.normal_index = i0.vn_idx;
+              idx0.texcoord_index = i0.vt_idx;
+              idx1.vertex_index = i1.v_idx;
+              idx1.normal_index = i1.vn_idx;
+              idx1.texcoord_index = i1.vt_idx;
+              idx2.vertex_index = i2.v_idx;
+              idx2.normal_index = i2.vn_idx;
+              idx2.texcoord_index = i2.vt_idx;
+
+              shape->mesh.indices.push_back(idx0);
+              shape->mesh.indices.push_back(idx1);
+              shape->mesh.indices.push_back(idx2);
+
+              shape->mesh.num_face_vertices.push_back(3);
+              shape->mesh.material_ids.push_back(material_id);
+              shape->mesh.smoothing_group_ids.push_back(
+                  face.smoothing_group_id);
+            }
+          }
+#endif
+        }  // npolys
+      } else {
+        for (size_t k = 0; k < npolys; k++) {
+          index_t idx;
+          idx.vertex_index = face.vertex_indices[k].v_idx;
+          idx.normal_index = face.vertex_indices[k].vn_idx;
+          idx.texcoord_index = face.vertex_indices[k].vt_idx;
+          shape->mesh.indices.push_back(idx);
+        }
+
+        shape->mesh.num_face_vertices.push_back(
+            static_cast<unsigned int>(npolys));
+        shape->mesh.material_ids.push_back(material_id);  // per face
+        shape->mesh.smoothing_group_ids.push_back(
+            face.smoothing_group_id);  // per face
+      }
+    }
+
+    shape->mesh.tags = tags;
+  }
+
+  // line
+  if (!prim_group.lineGroup.empty()) {
+    // Flatten indices
+    for (size_t i = 0; i < prim_group.lineGroup.size(); i++) {
+      for (size_t j = 0; j < prim_group.lineGroup[i].vertex_indices.size();
+           j++) {
+        const vertex_index_t &vi = prim_group.lineGroup[i].vertex_indices[j];
+
+        index_t idx;
+        idx.vertex_index = vi.v_idx;
+        idx.normal_index = vi.vn_idx;
+        idx.texcoord_index = vi.vt_idx;
+
+        shape->lines.indices.push_back(idx);
+      }
+
+      shape->lines.num_line_vertices.push_back(
+          int(prim_group.lineGroup[i].vertex_indices.size()));
+    }
+  }
+
+  // points
+  if (!prim_group.pointsGroup.empty()) {
+    // Flatten & convert indices
+    for (size_t i = 0; i < prim_group.pointsGroup.size(); i++) {
+      for (size_t j = 0; j < prim_group.pointsGroup[i].vertex_indices.size();
+           j++) {
+        const vertex_index_t &vi = prim_group.pointsGroup[i].vertex_indices[j];
+
+        index_t idx;
+        idx.vertex_index = vi.v_idx;
+        idx.normal_index = vi.vn_idx;
+        idx.texcoord_index = vi.vt_idx;
+
+        shape->points.indices.push_back(idx);
+      }
+    }
+  }
+
+  return true;
+}
+
+// Split a string with specified delimiter character and escape character.
+// https://rosettacode.org/wiki/Tokenize_a_string_with_escaping#C.2B.2B
+static void SplitString(const std::string &s, char delim, char escape,
+                        std::vector<std::string> &elems) {
+  std::string token;
+
+  bool escaping = false;
+  for (size_t i = 0; i < s.size(); ++i) {
+    char ch = s[i];
+    if (escaping) {
+      escaping = false;
+    } else if (ch == escape) {
+      if ((i + 1) < s.size()) {
+        const char next = s[i + 1];
+        if ((next == delim) || (next == escape)) {
+          escaping = true;
+          continue;
+        }
+      }
+    } else if (ch == delim) {
+      if (!token.empty()) {
+        elems.push_back(token);
+      }
+      token.clear();
+      continue;
+    }
+    token += ch;
+  }
+
+  elems.push_back(token);
+}
+
+static void RemoveEmptyTokens(std::vector<std::string> *tokens) {
+  if (!tokens) return;
+
+  const std::vector<std::string> &src = *tokens;
+  std::vector<std::string> filtered;
+  filtered.reserve(src.size());
+  for (size_t i = 0; i < src.size(); i++) {
+    if (!src[i].empty()) {
+      filtered.push_back(src[i]);
+    }
+  }
+  tokens->swap(filtered);
+}
+
+static std::string JoinPath(const std::string &dir,
+                            const std::string &filename) {
+  if (dir.empty()) {
+    return filename;
+  } else {
+    // check '/'
+    char lastChar = *dir.rbegin();
+    if (lastChar != '/') {
+      return dir + std::string("/") + filename;
+    } else {
+      return dir + filename;
+    }
+  }
+}
+
+static bool LoadMtlInternal(std::map<std::string, int> *material_map,
+                            std::vector<material_t> *materials,
+                            StreamReader &sr,
+                            std::string *warning, std::string *err,
+                            const std::string &filename = "<stream>") {
+  if (sr.has_errors()) {
+    if (err) {
+      (*err) += sr.get_errors();
+    }
+    return false;
+  }
+
+  material_t material;
+  InitMaterial(&material);
+
+  // Issue 43. `d` wins against `Tr` since `Tr` is not in the MTL specification.
+  bool has_d = false;
+  bool has_tr = false;
+
+  // has_kd is used to set a default diffuse value when map_Kd is present
+  // and Kd is not.
+  bool has_kd = false;
+
+  std::stringstream warn_ss;
+
+  // Handle BOM
+  if (sr.remaining() >= 3 &&
+      static_cast<unsigned char>(sr.peek()) == 0xEF &&
+      static_cast<unsigned char>(sr.peek_at(1)) == 0xBB &&
+      static_cast<unsigned char>(sr.peek_at(2)) == 0xBF) {
+    sr.advance(3);
+  }
+
+  while (!sr.eof()) {
+    sr.skip_space();
+    if (sr.at_line_end()) { sr.skip_line(); continue; }
+    if (sr.peek() == '#') { sr.skip_line(); continue; }
+
+    size_t line_num = sr.line_num();
+
+    // new mtl
+    if (sr.match("newmtl", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      // flush previous material.
+      if (!material.name.empty()) {
+        material_map->insert(std::pair<std::string, int>(
+            material.name, static_cast<int>(materials->size())));
+        materials->push_back(material);
+      }
+
+      InitMaterial(&material);
+
+      has_d = false;
+      has_tr = false;
+      has_kd = false;
+
+      sr.advance(7);
+      {
+        std::string namebuf = sr_parseString(sr);
+        if (namebuf.empty()) {
+          if (warning) {
+            (*warning) += "empty material name in `newmtl`\n";
+          }
+        }
+        material.name = namebuf;
+      }
+      sr.skip_line();
+      continue;
+    }
+
+    // ambient
+    if (sr.peek() == 'K' && sr.peek_at(1) == 'a' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      real_t r, g, b;
+      if (!sr_parseReal3(&r, &g, &b, sr, err, filename)) return false;
+      material.ambient[0] = r;
+      material.ambient[1] = g;
+      material.ambient[2] = b;
+      sr.skip_line();
+      continue;
+    }
+
+    // diffuse
+    if (sr.peek() == 'K' && sr.peek_at(1) == 'd' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      real_t r, g, b;
+      if (!sr_parseReal3(&r, &g, &b, sr, err, filename)) return false;
+      material.diffuse[0] = r;
+      material.diffuse[1] = g;
+      material.diffuse[2] = b;
+      has_kd = true;
+      sr.skip_line();
+      continue;
+    }
+
+    // specular
+    if (sr.peek() == 'K' && sr.peek_at(1) == 's' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      real_t r, g, b;
+      if (!sr_parseReal3(&r, &g, &b, sr, err, filename)) return false;
+      material.specular[0] = r;
+      material.specular[1] = g;
+      material.specular[2] = b;
+      sr.skip_line();
+      continue;
+    }
+
+    // transmittance
+    if ((sr.peek() == 'K' && sr.peek_at(1) == 't' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) ||
+        (sr.peek() == 'T' && sr.peek_at(1) == 'f' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t'))) {
+      sr.advance(2);
+      real_t r, g, b;
+      if (!sr_parseReal3(&r, &g, &b, sr, err, filename)) return false;
+      material.transmittance[0] = r;
+      material.transmittance[1] = g;
+      material.transmittance[2] = b;
+      sr.skip_line();
+      continue;
+    }
+
+    // ior(index of refraction)
+    if (sr.peek() == 'N' && sr.peek_at(1) == 'i' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      if (!sr_parseReal(sr, &material.ior, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // emission
+    if (sr.peek() == 'K' && sr.peek_at(1) == 'e' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      real_t r, g, b;
+      if (!sr_parseReal3(&r, &g, &b, sr, err, filename)) return false;
+      material.emission[0] = r;
+      material.emission[1] = g;
+      material.emission[2] = b;
+      sr.skip_line();
+      continue;
+    }
+
+    // shininess
+    if (sr.peek() == 'N' && sr.peek_at(1) == 's' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      if (!sr_parseReal(sr, &material.shininess, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // illum model
+    if (sr.match("illum", 5) && (sr.peek_at(5) == ' ' || sr.peek_at(5) == '\t')) {
+      sr.advance(6);
+      if (!sr_parseInt(sr, &material.illum, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // dissolve
+    if (sr.peek() == 'd' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(1);
+      if (!sr_parseReal(sr, &material.dissolve, 0.0, err, filename)) return false;
+
+      if (has_tr) {
+        warn_ss << "Both `d` and `Tr` parameters defined for \""
+                << material.name
+                << "\". Use the value of `d` for dissolve (line " << line_num
+                << " in .mtl.)\n";
+      }
+      has_d = true;
+      sr.skip_line();
+      continue;
+    }
+    if (sr.peek() == 'T' && sr.peek_at(1) == 'r' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      if (has_d) {
+        warn_ss << "Both `d` and `Tr` parameters defined for \""
+                << material.name
+                << "\". Use the value of `d` for dissolve (line " << line_num
+                << " in .mtl.)\n";
+      } else {
+        real_t tr_val;
+        if (!sr_parseReal(sr, &tr_val, 0.0, err, filename)) return false;
+        material.dissolve = static_cast<real_t>(1.0) - tr_val;
+      }
+      has_tr = true;
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: roughness
+    if (sr.peek() == 'P' && sr.peek_at(1) == 'r' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      if (!sr_parseReal(sr, &material.roughness, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: metallic
+    if (sr.peek() == 'P' && sr.peek_at(1) == 'm' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      if (!sr_parseReal(sr, &material.metallic, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: sheen
+    if (sr.peek() == 'P' && sr.peek_at(1) == 's' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      if (!sr_parseReal(sr, &material.sheen, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: clearcoat thickness
+    if (sr.peek() == 'P' && sr.peek_at(1) == 'c' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(2);
+      if (!sr_parseReal(sr, &material.clearcoat_thickness, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: clearcoat roughness
+    if (sr.match("Pcr", 3) && (sr.peek_at(3) == ' ' || sr.peek_at(3) == '\t')) {
+      sr.advance(4);
+      if (!sr_parseReal(sr, &material.clearcoat_roughness, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: anisotropy
+    if (sr.match("aniso", 5) && (sr.peek_at(5) == ' ' || sr.peek_at(5) == '\t')) {
+      sr.advance(6);
+      if (!sr_parseReal(sr, &material.anisotropy, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: anisotropy rotation
+    if (sr.match("anisor", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      if (!sr_parseReal(sr, &material.anisotropy_rotation, 0.0, err, filename)) return false;
+      sr.skip_line();
+      continue;
+    }
+
+    // For texture directives, read rest of line and delegate to
+    // ParseTextureNameAndOption (which uses the old const char* parse functions).
+
+    // ambient or ambient occlusion texture
+    if (sr.match("map_Ka", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.ambient_texname),
+                                &(material.ambient_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // diffuse texture
+    if (sr.match("map_Kd", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.diffuse_texname),
+                                &(material.diffuse_texopt), line_rest.c_str());
+      if (!has_kd) {
+        material.diffuse[0] = static_cast<real_t>(0.6);
+        material.diffuse[1] = static_cast<real_t>(0.6);
+        material.diffuse[2] = static_cast<real_t>(0.6);
+      }
+      sr.skip_line();
+      continue;
+    }
+
+    // specular texture
+    if (sr.match("map_Ks", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.specular_texname),
+                                &(material.specular_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // specular highlight texture
+    if (sr.match("map_Ns", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.specular_highlight_texname),
+                                &(material.specular_highlight_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // bump texture
+    if ((sr.match("map_bump", 8) || sr.match("map_Bump", 8)) &&
+        (sr.peek_at(8) == ' ' || sr.peek_at(8) == '\t')) {
+      sr.advance(9);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.bump_texname),
+                                &(material.bump_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // bump texture (short form)
+    if (sr.match("bump", 4) && (sr.peek_at(4) == ' ' || sr.peek_at(4) == '\t')) {
+      sr.advance(5);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.bump_texname),
+                                &(material.bump_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // alpha texture
+    if (sr.match("map_d", 5) && (sr.peek_at(5) == ' ' || sr.peek_at(5) == '\t')) {
+      sr.advance(6);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.alpha_texname),
+                                &(material.alpha_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // displacement texture
+    if ((sr.match("map_disp", 8) || sr.match("map_Disp", 8)) &&
+        (sr.peek_at(8) == ' ' || sr.peek_at(8) == '\t')) {
+      sr.advance(9);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.displacement_texname),
+                                &(material.displacement_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // displacement texture (short form)
+    if (sr.match("disp", 4) && (sr.peek_at(4) == ' ' || sr.peek_at(4) == '\t')) {
+      sr.advance(5);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.displacement_texname),
+                                &(material.displacement_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // reflection map
+    if (sr.match("refl", 4) && (sr.peek_at(4) == ' ' || sr.peek_at(4) == '\t')) {
+      sr.advance(5);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.reflection_texname),
+                                &(material.reflection_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: roughness texture
+    if (sr.match("map_Pr", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.roughness_texname),
+                                &(material.roughness_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: metallic texture
+    if (sr.match("map_Pm", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.metallic_texname),
+                                &(material.metallic_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: sheen texture
+    if (sr.match("map_Ps", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.sheen_texname),
+                                &(material.sheen_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: emissive texture
+    if (sr.match("map_Ke", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(7);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.emissive_texname),
+                                &(material.emissive_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // PBR: normal map texture
+    if (sr.match("norm", 4) && (sr.peek_at(4) == ' ' || sr.peek_at(4) == '\t')) {
+      sr.advance(5);
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      ParseTextureNameAndOption(&(material.normal_texname),
+                                &(material.normal_texopt), line_rest.c_str());
+      sr.skip_line();
+      continue;
+    }
+
+    // unknown parameter
+    {
+      std::string line_rest = trimTrailingWhitespace(sr.read_line());
+      const char *_lp = line_rest.c_str();
+      const char *_space = strchr(_lp, ' ');
+      if (!_space) {
+        _space = strchr(_lp, '\t');
+      }
+      if (_space) {
+        std::ptrdiff_t len = _space - _lp;
+        std::string key(_lp, static_cast<size_t>(len));
+        std::string value = _space + 1;
+        material.unknown_parameter.insert(
+            std::pair<std::string, std::string>(key, value));
+      }
+    }
+    sr.skip_line();
+  }
+  // flush last material (only if it was actually defined).
+  if (!material.name.empty()) {
+    material_map->insert(std::pair<std::string, int>(
+        material.name, static_cast<int>(materials->size())));
+    materials->push_back(material);
+  }
+
+  if (warning) {
+    (*warning) += warn_ss.str();
+  }
+
+  return true;
+}
+
+void LoadMtl(std::map<std::string, int> *material_map,
+             std::vector<material_t> *materials, std::istream *inStream,
+             std::string *warning, std::string *err) {
+  StreamReader sr(*inStream);
+  LoadMtlInternal(material_map, materials, sr, warning, err);
+}
+
+
+bool MaterialFileReader::operator()(const std::string &matId,
+                                    std::vector<material_t> *materials,
+                                    std::map<std::string, int> *matMap,
+                                    std::string *warn, std::string *err) {
+  if (!m_mtlBaseDir.empty()) {
+#ifdef _WIN32
+    char sep = ';';
+#else
+    char sep = ':';
+#endif
+
+    // https://stackoverflow.com/questions/5167625/splitting-a-c-stdstring-using-tokens-e-g
+    std::vector<std::string> paths;
+    std::istringstream f(m_mtlBaseDir);
+
+    std::string s;
+    while (getline(f, s, sep)) {
+      paths.push_back(s);
+    }
+
+    for (size_t i = 0; i < paths.size(); i++) {
+      std::string filepath = JoinPath(paths[i], matId);
+
+#ifdef TINYOBJLOADER_USE_MMAP
+      {
+        MappedFile mf;
+        if (!mf.open(filepath.c_str())) continue;
+        if (mf.size > TINYOBJLOADER_STREAM_READER_MAX_BYTES) {
+          if (err) {
+            std::stringstream ss;
+            ss << "input stream too large (" << mf.size
+               << " bytes exceeds limit "
+               << TINYOBJLOADER_STREAM_READER_MAX_BYTES << " bytes)\n";
+            (*err) += ss.str();
+          }
+          return false;
+        }
+        StreamReader sr(mf.data, mf.size);
+        return LoadMtlInternal(matMap, materials, sr, warn, err, filepath);
+      }
+#else   // !TINYOBJLOADER_USE_MMAP
+#ifdef _WIN32
+      std::ifstream matIStream(LongPathW(UTF8ToWchar(filepath)).c_str());
+#else
+      std::ifstream matIStream(filepath.c_str());
+#endif
+      if (matIStream) {
+        StreamReader mtl_sr(matIStream);
+        return LoadMtlInternal(matMap, materials, mtl_sr, warn, err, filepath);
+      }
+#endif  // TINYOBJLOADER_USE_MMAP
+    }
+
+    std::stringstream ss;
+    ss << "Material file [ " << matId
+       << " ] not found in a path : " << m_mtlBaseDir << "\n";
+    if (warn) {
+      (*warn) += ss.str();
+    }
+    return false;
+
+  } else {
+    std::string filepath = matId;
+
+#ifdef TINYOBJLOADER_USE_MMAP
+    {
+      MappedFile mf;
+      if (mf.open(filepath.c_str())) {
+        if (mf.size > TINYOBJLOADER_STREAM_READER_MAX_BYTES) {
+          if (err) {
+            std::stringstream ss;
+            ss << "input stream too large (" << mf.size
+               << " bytes exceeds limit "
+               << TINYOBJLOADER_STREAM_READER_MAX_BYTES << " bytes)\n";
+            (*err) += ss.str();
+          }
+          return false;
+        }
+        StreamReader sr(mf.data, mf.size);
+        return LoadMtlInternal(matMap, materials, sr, warn, err, filepath);
+      }
+    }
+#else   // !TINYOBJLOADER_USE_MMAP
+#ifdef _WIN32
+    std::ifstream matIStream(LongPathW(UTF8ToWchar(filepath)).c_str());
+#else
+    std::ifstream matIStream(filepath.c_str());
+#endif
+    if (matIStream) {
+      StreamReader mtl_sr(matIStream);
+      return LoadMtlInternal(matMap, materials, mtl_sr, warn, err, filepath);
+    }
+#endif  // TINYOBJLOADER_USE_MMAP
+
+    std::stringstream ss;
+    ss << "Material file [ " << filepath
+       << " ] not found in a path : " << m_mtlBaseDir << "\n";
+    if (warn) {
+      (*warn) += ss.str();
+    }
+
+    return false;
+  }
+}
+
+bool MaterialStreamReader::operator()(const std::string &matId,
+                                      std::vector<material_t> *materials,
+                                      std::map<std::string, int> *matMap,
+                                      std::string *warn, std::string *err) {
+  (void)matId;
+  if (!m_inStream) {
+    std::stringstream ss;
+    ss << "Material stream in error state. \n";
+    if (warn) {
+      (*warn) += ss.str();
+    }
+    return false;
+  }
+
+  StreamReader mtl_sr(m_inStream);
+  return LoadMtlInternal(matMap, materials, mtl_sr, warn, err, "<stream>");
+}
+
+static bool LoadObjInternal(attrib_t *attrib, std::vector<shape_t> *shapes,
+                            std::vector<material_t> *materials,
+                            std::string *warn, std::string *err,
+                            StreamReader &sr,
+                            MaterialReader *readMatFn, bool triangulate,
+                            bool default_vcols_fallback,
+                            const std::string &filename = "<stream>") {
+  if (sr.has_errors()) {
+    if (err) {
+      (*err) += sr.get_errors();
+    }
+    return false;
+  }
+
+  std::vector<real_t> v;
+  std::vector<real_t> vertex_weights;
+  std::vector<real_t> vn;
+  std::vector<real_t> vt;
+  std::vector<real_t> vt_w;  // optional [w] component in `vt`
+  std::vector<real_t> vc;
+  std::vector<skin_weight_t> vw;
+  std::vector<tag_t> tags;
+  PrimGroup prim_group;
+  std::string name;
+
+  // material
+  std::set<std::string> material_filenames;
+  std::map<std::string, int> material_map;
+  int material = -1;
+
+  unsigned int current_smoothing_id = 0;
+
+  int greatest_v_idx = -1;
+  int greatest_vn_idx = -1;
+  int greatest_vt_idx = -1;
+
+  shape_t shape;
+
+  bool found_all_colors = true;
+
+  // Handle BOM
+  if (sr.remaining() >= 3 &&
+      static_cast<unsigned char>(sr.peek()) == 0xEF &&
+      static_cast<unsigned char>(sr.peek_at(1)) == 0xBB &&
+      static_cast<unsigned char>(sr.peek_at(2)) == 0xBF) {
+    sr.advance(3);
+  }
+
+  warning_context context;
+  context.warn = warn;
+  context.filename = filename;
+
+  while (!sr.eof()) {
+    sr.skip_space();
+    if (sr.at_line_end()) { sr.skip_line(); continue; }
+    if (sr.peek() == '#') { sr.skip_line(); continue; }
+
+    size_t line_num = sr.line_num();
+
+    // vertex
+    if (sr.peek() == 'v' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(2);
+      real_t x, y, z;
+      real_t r, g, b;
+
+      int num_components = sr_parseVertexWithColor(&x, &y, &z, &r, &g, &b, sr, err, filename);
+      if (num_components < 0) return false;
+      found_all_colors &= (num_components == 6);
+
+      v.push_back(x);
+      v.push_back(y);
+      v.push_back(z);
+
+      vertex_weights.push_back(r);
+
+      if ((num_components == 6) || default_vcols_fallback) {
+        vc.push_back(r);
+        vc.push_back(g);
+        vc.push_back(b);
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // normal
+    if (sr.peek() == 'v' && sr.peek_at(1) == 'n' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(3);
+      real_t x, y, z;
+      if (!sr_parseReal3(&x, &y, &z, sr, err, filename)) return false;
+      vn.push_back(x);
+      vn.push_back(y);
+      vn.push_back(z);
+      sr.skip_line();
+      continue;
+    }
+
+    // texcoord
+    if (sr.peek() == 'v' && sr.peek_at(1) == 't' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(3);
+      real_t x, y;
+      if (!sr_parseReal2(&x, &y, sr, err, filename)) return false;
+      vt.push_back(x);
+      vt.push_back(y);
+
+      // Parse optional w component
+      real_t w = static_cast<real_t>(0.0);
+      sr_parseReal(sr, &w);
+      vt_w.push_back(w);
+
+      sr.skip_line();
+      continue;
+    }
+
+    // skin weight. tinyobj extension
+    if (sr.peek() == 'v' && sr.peek_at(1) == 'w' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(3);
+
+      int vid;
+      if (!sr_parseInt(sr, &vid, err, filename)) return false;
+
+      skin_weight_t sw;
+      sw.vertex_id = vid;
+
+      size_t vw_loop_max = sr.remaining() + 1;
+      size_t vw_loop_iter = 0;
+      while (!sr.at_line_end() && sr.peek() != '#' &&
+             vw_loop_iter < vw_loop_max) {
+        real_t j, w;
+        sr_parseReal2(&j, &w, sr, -1.0);
+
+        if (j < static_cast<real_t>(0)) {
+          if (err) {
+            (*err) += sr.format_error(filename,
+                "failed to parse `vw' line: joint_id is negative");
+          }
+          return false;
+        }
+
+        joint_and_weight_t jw;
+        jw.joint_id = int(j);
+        jw.weight = w;
+
+        sw.weightValues.push_back(jw);
+        sr.skip_space_and_cr();
+        vw_loop_iter++;
+      }
+
+      vw.push_back(sw);
+      sr.skip_line();
+      continue;
+    }
+
+    context.line_number = line_num;
+
+    // line
+    if (sr.peek() == 'l' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(2);
+
+      __line_t line;
+
+      size_t l_loop_max = sr.remaining() + 1;
+      size_t l_loop_iter = 0;
+      while (!sr.at_line_end() && sr.peek() != '#' &&
+             l_loop_iter < l_loop_max) {
+        vertex_index_t vi;
+        if (!sr_parseTriple(sr, size_to_int(v.size() / 3),
+                         size_to_int(vn.size() / 3),
+                         size_to_int(vt.size() / 2), &vi, context)) {
+          if (err) {
+            (*err) += sr.format_error(filename,
+                "failed to parse `l' line (invalid vertex index)");
+          }
+          return false;
+        }
+
+        line.vertex_indices.push_back(vi);
+        sr.skip_space_and_cr();
+        l_loop_iter++;
+      }
+
+      prim_group.lineGroup.push_back(line);
+      sr.skip_line();
+      continue;
+    }
+
+    // points
+    if (sr.peek() == 'p' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(2);
+
+      __points_t pts;
+
+      size_t p_loop_max = sr.remaining() + 1;
+      size_t p_loop_iter = 0;
+      while (!sr.at_line_end() && sr.peek() != '#' &&
+             p_loop_iter < p_loop_max) {
+        vertex_index_t vi;
+        if (!sr_parseTriple(sr, size_to_int(v.size() / 3),
+                         size_to_int(vn.size() / 3),
+                         size_to_int(vt.size() / 2), &vi, context)) {
+          if (err) {
+            (*err) += sr.format_error(filename,
+                "failed to parse `p' line (invalid vertex index)");
+          }
+          return false;
+        }
+
+        pts.vertex_indices.push_back(vi);
+        sr.skip_space_and_cr();
+        p_loop_iter++;
+      }
+
+      prim_group.pointsGroup.push_back(pts);
+      sr.skip_line();
+      continue;
+    }
+
+    // face
+    if (sr.peek() == 'f' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(2);
+      sr.skip_space();
+
+      face_t face;
+
+      face.smoothing_group_id = current_smoothing_id;
+      face.vertex_indices.reserve(3);
+
+      size_t f_loop_max = sr.remaining() + 1;
+      size_t f_loop_iter = 0;
+      while (!sr.at_line_end() && sr.peek() != '#' &&
+             f_loop_iter < f_loop_max) {
+        vertex_index_t vi;
+        if (!sr_parseTriple(sr, size_to_int(v.size() / 3),
+                         size_to_int(vn.size() / 3),
+                         size_to_int(vt.size() / 2), &vi, context)) {
+          if (err) {
+            (*err) += sr.format_error(filename,
+                "failed to parse `f' line (invalid vertex index)");
+          }
+          return false;
+        }
+
+        greatest_v_idx = greatest_v_idx > vi.v_idx ? greatest_v_idx : vi.v_idx;
+        greatest_vn_idx =
+            greatest_vn_idx > vi.vn_idx ? greatest_vn_idx : vi.vn_idx;
+        greatest_vt_idx =
+            greatest_vt_idx > vi.vt_idx ? greatest_vt_idx : vi.vt_idx;
+
+        face.vertex_indices.push_back(vi);
+        sr.skip_space_and_cr();
+        f_loop_iter++;
+      }
+
+      prim_group.faceGroup.push_back(face);
+      sr.skip_line();
+      continue;
+    }
+
+    // use mtl
+    if (sr.match("usemtl", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(6);
+      std::string namebuf = sr_parseString(sr);
+
+      int newMaterialId = -1;
+      std::map<std::string, int>::const_iterator it =
+          material_map.find(namebuf);
+      if (it != material_map.end()) {
+        newMaterialId = it->second;
+      } else {
+        if (warn) {
+          (*warn) += "material [ '" + namebuf + "' ] not found in .mtl\n";
+        }
+      }
+
+      if (newMaterialId != material) {
+        exportGroupsToShape(&shape, prim_group, tags, material, name,
+                            triangulate, v, warn);
+        prim_group.faceGroup.clear();
+        material = newMaterialId;
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // load mtl
+    if (sr.match("mtllib", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      if (readMatFn) {
+        sr.advance(7);
+
+        std::string line_rest = trimTrailingWhitespace(sr.read_line());
+        std::vector<std::string> filenames;
+        SplitString(line_rest, ' ', '\\', filenames);
+        RemoveEmptyTokens(&filenames);
+
+        if (filenames.empty()) {
+          if (warn) {
+            std::stringstream ss;
+            ss << "Looks like empty filename for mtllib. Use default "
+                  "material (line "
+               << line_num << ".)\n";
+
+            (*warn) += ss.str();
+          }
+        } else {
+          bool found = false;
+          for (size_t s = 0; s < filenames.size(); s++) {
+            if (material_filenames.count(filenames[s]) > 0) {
+              found = true;
+              continue;
+            }
+
+            std::string warn_mtl;
+            std::string err_mtl;
+            bool ok = (*readMatFn)(filenames[s].c_str(), materials,
+                                   &material_map, &warn_mtl, &err_mtl);
+            if (warn && (!warn_mtl.empty())) {
+              (*warn) += warn_mtl;
+            }
+
+            if (err && (!err_mtl.empty())) {
+              (*err) += err_mtl;
+            }
+
+            if (ok) {
+              found = true;
+              material_filenames.insert(filenames[s]);
+              break;
+            }
+          }
+
+          if (!found) {
+            if (warn) {
+              (*warn) +=
+                  "Failed to load material file(s). Use default "
+                  "material.\n";
+            }
+          }
+        }
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // group name
+    if (sr.peek() == 'g' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      // flush previous face group.
+      bool ret = exportGroupsToShape(&shape, prim_group, tags, material, name,
+                                     triangulate, v, warn);
+      (void)ret;
+
+      if (shape.mesh.indices.size() > 0) {
+        shapes->push_back(shape);
+      }
+
+      shape = shape_t();
+
+      // material = -1;
+      prim_group.clear();
+
+      std::vector<std::string> names;
+
+      size_t g_loop_max = sr.remaining() + 1;
+      size_t g_loop_iter = 0;
+      while (!sr.at_line_end() && sr.peek() != '#' &&
+             g_loop_iter < g_loop_max) {
+        std::string str = sr_parseString(sr);
+        names.push_back(str);
+        sr.skip_space_and_cr();
+        g_loop_iter++;
+      }
+
+      // names[0] must be 'g'
+
+      if (names.size() < 2) {
+        // 'g' with empty names
+        if (warn) {
+          std::stringstream ss;
+          ss << "Empty group name. line: " << line_num << "\n";
+          (*warn) += ss.str();
+          name = "";
+        }
+      } else {
+        std::stringstream ss;
+        ss << names[1];
+
+        for (size_t i = 2; i < names.size(); i++) {
+          ss << " " << names[i];
+        }
+
+        name = ss.str();
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // object name
+    if (sr.peek() == 'o' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      // flush previous face group.
+      bool ret = exportGroupsToShape(&shape, prim_group, tags, material, name,
+                                     triangulate, v, warn);
+      (void)ret;
+
+      if (shape.mesh.indices.size() > 0 || shape.lines.indices.size() > 0 ||
+          shape.points.indices.size() > 0) {
+        shapes->push_back(shape);
+      }
+
+      // material = -1;
+      prim_group.clear();
+      shape = shape_t();
+
+      sr.advance(2);
+      std::string rest = sr.read_line();
+      name = rest;
+
+      sr.skip_line();
+      continue;
+    }
+
+    if (sr.peek() == 't' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      const int max_tag_nums = 8192;
+      tag_t tag;
+
+      sr.advance(2);
+
+      tag.name = sr_parseString(sr);
+
+      tag_sizes ts = sr_parseTagTriple(sr);
+
+      if (ts.num_ints < 0) {
+        ts.num_ints = 0;
+      }
+      if (ts.num_ints > max_tag_nums) {
+        ts.num_ints = max_tag_nums;
+      }
+
+      if (ts.num_reals < 0) {
+        ts.num_reals = 0;
+      }
+      if (ts.num_reals > max_tag_nums) {
+        ts.num_reals = max_tag_nums;
+      }
+
+      if (ts.num_strings < 0) {
+        ts.num_strings = 0;
+      }
+      if (ts.num_strings > max_tag_nums) {
+        ts.num_strings = max_tag_nums;
+      }
+
+      tag.intValues.resize(static_cast<size_t>(ts.num_ints));
+
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_ints); ++i) {
+        tag.intValues[i] = sr_parseInt(sr);
+      }
+
+      tag.floatValues.resize(static_cast<size_t>(ts.num_reals));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_reals); ++i) {
+        tag.floatValues[i] = sr_parseReal(sr);
+      }
+
+      tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
+        tag.stringValues[i] = sr_parseString(sr);
+      }
+
+      tags.push_back(tag);
+
+      sr.skip_line();
+      continue;
+    }
+
+    if (sr.peek() == 's' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      // smoothing group id
+      sr.advance(2);
+      sr.skip_space();
+
+      if (sr.at_line_end()) {
+        sr.skip_line();
+        continue;
+      }
+
+      if (sr.peek() == '\r') {
+        sr.skip_line();
+        continue;
+      }
+
+      if (sr.remaining() >= 3 && sr.match("off", 3)) {
+        current_smoothing_id = 0;
+      } else {
+        int smGroupId = sr_parseInt(sr);
+        if (smGroupId < 0) {
+          current_smoothing_id = 0;
+        } else {
+          current_smoothing_id = static_cast<unsigned int>(smGroupId);
+        }
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // Ignore unknown command.
+    sr.skip_line();
+  }
+
+  // not all vertices have colors, no default colors desired? -> clear colors
+  if (!found_all_colors && !default_vcols_fallback) {
+    vc.clear();
+  }
+
+  if (greatest_v_idx >= size_to_int(v.size() / 3)) {
+    if (warn) {
+      std::stringstream ss;
+      ss << "Vertex indices out of bounds (line " << sr.line_num() << ".)\n\n";
+      (*warn) += ss.str();
+    }
+  }
+  if (greatest_vn_idx >= size_to_int(vn.size() / 3)) {
+    if (warn) {
+      std::stringstream ss;
+      ss << "Vertex normal indices out of bounds (line " << sr.line_num()
+         << ".)\n\n";
+      (*warn) += ss.str();
+    }
+  }
+  if (greatest_vt_idx >= size_to_int(vt.size() / 2)) {
+    if (warn) {
+      std::stringstream ss;
+      ss << "Vertex texcoord indices out of bounds (line " << sr.line_num()
+         << ".)\n\n";
+      (*warn) += ss.str();
+    }
+  }
+
+  bool ret = exportGroupsToShape(&shape, prim_group, tags, material, name,
+                                 triangulate, v, warn);
+  if (ret || shape.mesh.indices.size()) {
+    shapes->push_back(shape);
+  }
+  prim_group.clear();
+
+  attrib->vertices.swap(v);
+  attrib->vertex_weights.swap(vertex_weights);
+  attrib->normals.swap(vn);
+  attrib->texcoords.swap(vt);
+  attrib->texcoord_ws.swap(vt_w);
+  attrib->colors.swap(vc);
+  attrib->skin_weights.swap(vw);
+
+  return true;
+}
+
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, const char *filename, const char *mtl_basedir,
+             bool triangulate, bool default_vcols_fallback) {
+  attrib->vertices.clear();
+  attrib->vertex_weights.clear();
+  attrib->normals.clear();
+  attrib->texcoords.clear();
+  attrib->texcoord_ws.clear();
+  attrib->colors.clear();
+  attrib->skin_weights.clear();
+  shapes->clear();
+
+  std::string baseDir = mtl_basedir ? mtl_basedir : "";
+  if (!baseDir.empty()) {
+#ifndef _WIN32
+    const char dirsep = '/';
+#else
+    const char dirsep = '\\';
+#endif
+    if (baseDir[baseDir.length() - 1] != dirsep) baseDir += dirsep;
+  }
+  MaterialFileReader matFileReader(baseDir);
+
+#ifdef TINYOBJLOADER_USE_MMAP
+  {
+    MappedFile mf;
+    if (!mf.open(filename)) {
+      if (err) {
+        std::stringstream ss;
+        ss << "Cannot open file [" << filename << "]\n";
+        (*err) = ss.str();
+      }
+      return false;
+    }
+    if (mf.size > TINYOBJLOADER_STREAM_READER_MAX_BYTES) {
+      if (err) {
+        std::stringstream ss;
+        ss << "input stream too large (" << mf.size
+           << " bytes exceeds limit "
+           << TINYOBJLOADER_STREAM_READER_MAX_BYTES << " bytes)\n";
+        (*err) += ss.str();
+      }
+      return false;
+    }
+    StreamReader sr(mf.data, mf.size);
+    return LoadObjInternal(attrib, shapes, materials, warn, err, sr,
+                           &matFileReader, triangulate, default_vcols_fallback,
+                           filename);
+  }
+#else   // !TINYOBJLOADER_USE_MMAP
+#ifdef _WIN32
+  std::ifstream ifs(LongPathW(UTF8ToWchar(filename)).c_str());
+#else
+  std::ifstream ifs(filename);
+#endif
+  if (!ifs) {
+    if (err) {
+      std::stringstream ss;
+      ss << "Cannot open file [" << filename << "]\n";
+      (*err) = ss.str();
+    }
+    return false;
+  }
+  {
+    StreamReader sr(ifs);
+    return LoadObjInternal(attrib, shapes, materials, warn, err, sr,
+                           &matFileReader, triangulate, default_vcols_fallback,
+                           filename);
+  }
+#endif  // TINYOBJLOADER_USE_MMAP
+}
+
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, std::istream *inStream,
+             MaterialReader *readMatFn /*= NULL*/, bool triangulate,
+             bool default_vcols_fallback) {
+  attrib->vertices.clear();
+  attrib->vertex_weights.clear();
+  attrib->normals.clear();
+  attrib->texcoords.clear();
+  attrib->texcoord_ws.clear();
+  attrib->colors.clear();
+  attrib->skin_weights.clear();
+  shapes->clear();
+
+  StreamReader sr(*inStream);
+  return LoadObjInternal(attrib, shapes, materials, warn, err, sr,
+                         readMatFn, triangulate, default_vcols_fallback);
+}
+
+
+static bool LoadObjWithCallbackInternal(StreamReader &sr,
+                                        const callback_t &callback,
+                                        void *user_data,
+                                        MaterialReader *readMatFn,
+                                        std::string *warn,
+                                        std::string *err) {
+  if (sr.has_errors()) {
+    if (err) {
+      (*err) += sr.get_errors();
+    }
+    return false;
+  }
+
+  // material
+  std::set<std::string> material_filenames;
+  std::map<std::string, int> material_map;
+  int material_id = -1;
+
+  std::vector<index_t> indices;
+  std::vector<material_t> materials;
+  std::vector<std::string> names;
+  names.reserve(2);
+  std::vector<const char *> names_out;
+
+  // Handle BOM
+  if (sr.remaining() >= 3 &&
+      static_cast<unsigned char>(sr.peek()) == 0xEF &&
+      static_cast<unsigned char>(sr.peek_at(1)) == 0xBB &&
+      static_cast<unsigned char>(sr.peek_at(2)) == 0xBF) {
+    sr.advance(3);
+  }
+
+  while (!sr.eof()) {
+    sr.skip_space();
+    if (sr.at_line_end()) { sr.skip_line(); continue; }
+    if (sr.peek() == '#') { sr.skip_line(); continue; }
+
+    // vertex
+    if (sr.peek() == 'v' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(2);
+      real_t x, y, z;
+      real_t r, g, b;
+
+      int num_components = sr_parseVertexWithColor(&x, &y, &z, &r, &g, &b, sr, err, std::string());
+      if (num_components < 0) {
+        return false;
+      }
+      if (callback.vertex_cb) {
+        callback.vertex_cb(user_data, x, y, z, r);
+      }
+      if (callback.vertex_color_cb) {
+        bool found_color = (num_components == 6);
+        callback.vertex_color_cb(user_data, x, y, z, r, g, b, found_color);
+      }
+      sr.skip_line();
+      continue;
+    }
+
+    // normal
+    if (sr.peek() == 'v' && sr.peek_at(1) == 'n' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(3);
+      real_t x, y, z;
+      sr_parseReal3(&x, &y, &z, sr);
+      if (callback.normal_cb) {
+        callback.normal_cb(user_data, x, y, z);
+      }
+      sr.skip_line();
+      continue;
+    }
+
+    // texcoord
+    if (sr.peek() == 'v' && sr.peek_at(1) == 't' && (sr.peek_at(2) == ' ' || sr.peek_at(2) == '\t')) {
+      sr.advance(3);
+      real_t x, y, z;
+      sr_parseReal3(&x, &y, &z, sr);
+      if (callback.texcoord_cb) {
+        callback.texcoord_cb(user_data, x, y, z);
+      }
+      sr.skip_line();
+      continue;
+    }
+
+    // face
+    if (sr.peek() == 'f' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(2);
+      sr.skip_space();
+
+      indices.clear();
+      size_t cf_loop_max = sr.remaining() + 1;
+      size_t cf_loop_iter = 0;
+      while (!sr.at_line_end() && sr.peek() != '#' &&
+             cf_loop_iter < cf_loop_max) {
+        vertex_index_t vi = sr_parseRawTriple(sr);
+
+        index_t idx;
+        idx.vertex_index = vi.v_idx;
+        idx.normal_index = vi.vn_idx;
+        idx.texcoord_index = vi.vt_idx;
+
+        indices.push_back(idx);
+        sr.skip_space_and_cr();
+        cf_loop_iter++;
+      }
+
+      if (callback.index_cb && indices.size() > 0) {
+        callback.index_cb(user_data, &indices.at(0),
+                          static_cast<int>(indices.size()));
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // use mtl
+    if (sr.match("usemtl", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      sr.advance(6);
+      std::string namebuf = sr_parseString(sr);
+
+      int newMaterialId = -1;
+      std::map<std::string, int>::const_iterator it =
+          material_map.find(namebuf);
+      if (it != material_map.end()) {
+        newMaterialId = it->second;
+      } else {
+        if (warn && (!callback.usemtl_cb)) {
+          (*warn) += "material [ " + namebuf + " ] not found in .mtl\n";
+        }
+      }
+
+      if (newMaterialId != material_id) {
+        material_id = newMaterialId;
+      }
+
+      if (callback.usemtl_cb) {
+        callback.usemtl_cb(user_data, namebuf.c_str(), material_id);
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // load mtl
+    if (sr.match("mtllib", 6) && (sr.peek_at(6) == ' ' || sr.peek_at(6) == '\t')) {
+      if (readMatFn) {
+        sr.advance(7);
+
+        std::string line_rest = trimTrailingWhitespace(sr.read_line());
+        std::vector<std::string> filenames;
+        SplitString(line_rest, ' ', '\\', filenames);
+        RemoveEmptyTokens(&filenames);
+
+        if (filenames.empty()) {
+          if (warn) {
+            (*warn) +=
+                "Looks like empty filename for mtllib. Use default "
+                "material. \n";
+          }
+        } else {
+          bool found = false;
+          for (size_t s = 0; s < filenames.size(); s++) {
+            if (material_filenames.count(filenames[s]) > 0) {
+              found = true;
+              continue;
+            }
+
+            std::string warn_mtl;
+            std::string err_mtl;
+            bool ok = (*readMatFn)(filenames[s].c_str(), &materials,
+                                   &material_map, &warn_mtl, &err_mtl);
+
+            if (warn && (!warn_mtl.empty())) {
+              (*warn) += warn_mtl;
+            }
+
+            if (err && (!err_mtl.empty())) {
+              (*err) += err_mtl;
+            }
+
+            if (ok) {
+              found = true;
+              material_filenames.insert(filenames[s]);
+              break;
+            }
+          }
+
+          if (!found) {
+            if (warn) {
+              (*warn) +=
+                  "Failed to load material file(s). Use default "
+                  "material.\n";
+            }
+          } else {
+            if (callback.mtllib_cb && !materials.empty()) {
+              callback.mtllib_cb(user_data, &materials.at(0),
+                                 static_cast<int>(materials.size()));
+            }
+          }
+        }
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // group name
+    if (sr.peek() == 'g' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      names.clear();
+
+      size_t cg_loop_max = sr.remaining() + 1;
+      size_t cg_loop_iter = 0;
+      while (!sr.at_line_end() && sr.peek() != '#' &&
+             cg_loop_iter < cg_loop_max) {
+        std::string str = sr_parseString(sr);
+        names.push_back(str);
+        sr.skip_space_and_cr();
+        cg_loop_iter++;
+      }
+
+      assert(names.size() > 0);
+
+      if (callback.group_cb) {
+        if (names.size() > 1) {
+          names_out.resize(names.size() - 1);
+          for (size_t j = 0; j < names_out.size(); j++) {
+            names_out[j] = names[j + 1].c_str();
+          }
+          callback.group_cb(user_data, &names_out.at(0),
+                            static_cast<int>(names_out.size()));
+
+        } else {
+          callback.group_cb(user_data, NULL, 0);
+        }
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+    // object name
+    if (sr.peek() == 'o' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      sr.advance(2);
+      std::string object_name = sr.read_line();
+
+      if (callback.object_cb) {
+        callback.object_cb(user_data, object_name.c_str());
+      }
+
+      sr.skip_line();
+      continue;
+    }
+
+#if 0  // @todo
+    if (sr.peek() == 't' && (sr.peek_at(1) == ' ' || sr.peek_at(1) == '\t')) {
+      tag_t tag;
+
+      sr.advance(2);
+      tag.name = sr_parseString(sr);
+
+      tag_sizes ts = sr_parseTagTriple(sr);
+
+      tag.intValues.resize(static_cast<size_t>(ts.num_ints));
+
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_ints); ++i) {
+        tag.intValues[i] = sr_parseInt(sr);
+      }
+
+      tag.floatValues.resize(static_cast<size_t>(ts.num_reals));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_reals); ++i) {
+        tag.floatValues[i] = sr_parseReal(sr);
+      }
+
+      tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
+        tag.stringValues[i] = sr_parseString(sr);
+      }
+
+      tags.push_back(tag);
+    }
+#endif
+
+    // Ignore unknown command.
+    sr.skip_line();
+  }
+
+  return true;
+}
+
+bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
+                         void *user_data /*= NULL*/,
+                         MaterialReader *readMatFn /*= NULL*/,
+                         std::string *warn, /* = NULL*/
+                         std::string *err /*= NULL*/) {
+  StreamReader sr(inStream);
+  return LoadObjWithCallbackInternal(sr, callback, user_data, readMatFn,
+                                     warn, err);
+}
+
+bool ObjReader::ParseFromFile(const std::string &filename,
+                              const ObjReaderConfig &config) {
+  std::string mtl_search_path;
+
+  if (config.mtl_search_path.empty()) {
+    //
+    // split at last '/'(for unixish system) or '\\'(for windows) to get
+    // the base directory of .obj file
+    //
+    size_t pos = filename.find_last_of("/\\");
+    if (pos != std::string::npos) {
+      mtl_search_path = filename.substr(0, pos);
+    }
+  } else {
+    mtl_search_path = config.mtl_search_path;
+  }
+
+  valid_ = LoadObj(&attrib_, &shapes_, &materials_, &warning_, &error_,
+                   filename.c_str(), mtl_search_path.c_str(),
+                   config.triangulate, config.vertex_color);
+
+  return valid_;
+}
+
+bool ObjReader::ParseFromString(const std::string &obj_text,
+                                const std::string &mtl_text,
+                                const ObjReaderConfig &config) {
+  std::stringbuf obj_buf(obj_text);
+  std::stringbuf mtl_buf(mtl_text);
+
+  std::istream obj_ifs(&obj_buf);
+  std::istream mtl_ifs(&mtl_buf);
+
+  MaterialStreamReader mtl_ss(mtl_ifs);
+
+  valid_ = LoadObj(&attrib_, &shapes_, &materials_, &warning_, &error_,
+                   &obj_ifs, &mtl_ss, config.triangulate, config.vertex_color);
+
+  return valid_;
+}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+}  // namespace tinyobj
+
+#endif


### PR DESCRIPTION
## Context

We wanted to use pmugg as the back end of a "model → grammar" pipeline: hand-author a representative mesh in a 3D tool, run a converter on it, then let pmugg's mutator iterate from that seed shape. Previously the only path into pmugg was hand-authoring the entire grammar JSON, which is fiddly even for simple shapes.

This PR adds a new self-contained `mesh_extraction/` module that takes an OBJ file and produces a pmugg-loadable seed grammar JSON. The output round-trips through `GraphGrammar::import` — no schema gymnastics required on the calling side.

## What this PR does

**New module `cpp_version/mesh_extraction/`:**

- `obj_loader.{h,cpp}` — minimal OBJ reader over `tinyobjloader`. Returns the raw face / vertex / material data without triangulating.
- `half_edge_mesh.{h,cpp}` — builds a DCEL from the OBJ. Labels enclosed volumes by flood-fill (closed-manifold case: 0 = ambient, 1 = interior; `useGroupAsVolume` mode lets each named OBJ group become its own volume for multi-volume inputs).
- `type_extractor.{h,cpp}` — quantizes face normals and edge directions, canonicalizes the cyclic CCW σ-sequence around each vertex (lexicographically smallest rotation), and emits unique face / edge / vertex type lists with per-element indices into them. Currently implements Phase A — closed-manifold meshes with single-fan vertices. Phase B (general 3D σ-graphs) is a TODO marked in the header.
- `seed_grammar_writer.{h,cpp}` — serializes the half-edge mesh + extracted types into pmugg's grammar JSON schema. The result is a grammar with one starter rule that emits the seed shape from an empty graph.

**Vendored third-party dependency:**

- `cpp_version/third_party/tinyobjloader/tiny_obj_loader.h` — MIT-licensed v2.0.0 single-header OBJ parser. Used only by `obj_loader.cpp`, which is compiled with `PrecompiledHeader=NotUsing` so the `TINYOBJLOADER_IMPLEMENTATION` translation unit stays isolated from pmugg's PCH.

**Additive existing-file changes:**

- `cpp_version/pmugg/pmugg.cpp` — `main()` gains an opt-in CLI mode: `pmugg --mesh-to-grammar <input.obj> <output.json>`. With no args it behaves identically to before (still runs the four bundled grammars through the mutator).
- `cpp_version/pmugg/pmugg.vcxproj` — registers the new sources, sets `obj_loader.cpp` to `NotUsing` PCH, adds `..` to `AdditionalIncludeDirectories` so `#include "mesh_extraction/..."` resolves from `cpp_version/`.

**Test fixture:**

- `cpp_version/mesh_extraction/example_data/cube.obj` (+ `.mtl`) — 8 verts, 6 quad faces, single material. Smallest closed manifold that exercises every step of the pipeline.

## Why this design

- **Local `Vec3d` in `half_edge_mesh.h` instead of pmugg's `Vec3`.** The module is intended to be consumable from external tooling, which often has its own `Vec3`. Using a header-local struct avoids the collision; conversion to pmugg's type happens inside `seed_grammar_writer.cpp` only.
- **All new files; no behavior change to existing pmugg paths.** The mutator, optimizer, and grammar loader are untouched. The only modified files are `pmugg.cpp` (one CLI branch) and `pmugg.vcxproj` (new file registration + include path).
- **Output through `GraphGrammar::import` rather than a separate loader.** The seed-grammar writer emits exactly the JSON schema pmugg already understands. No new parsing code paths to maintain — and the output is editable by the same tools that handle hand-authored grammars.
- **Phase A only.** Closed-manifold + single-fan vertices covers the canonical mesh-to-grammar use case (closed primitive shapes feeding the mutator). Phase B (general 3D σ-graphs) is a deliberate future-work tag on the header so consumers don't ship code that depends on the current limitation.
- **PCH-isolated tinyobjloader.** `obj_loader.cpp` is the only file that needs `TINYOBJLOADER_IMPLEMENTATION` defined; pinning it to `NotUsing` PCH keeps that 100k-line single-header expansion out of the rest of the build.

## Verification

Built `pmugg.sln` standalone (Release / x64 / MSVC 19.x). Clean compile, no new warnings.

**Default-mode baseline** — running `pmugg.exe` with no args:

```
Num Faces: 265   (castle)
Num Faces: 4     (square filled)
Num Faces: 64    (house1)
Num Faces: 163   (docks)
```

Identical to `main`. The CLI addition is opt-in.

**Mesh-to-grammar repro:**

```
cd cpp_version\pmugg
..\x64\Release\pmugg.exe --mesh-to-grammar ..\mesh_extraction\example_data\cube.obj cube.seed.json
```

Output:

```
Wrote seed grammar to cube.seed.json (8 vertex types, 12 edge types, 6 face types)
  Round-trip: GraphGrammar::import succeeded.
```

The CLI loads the OBJ, builds the half-edge mesh, extracts types, writes the JSON, then loads the JSON back through `GraphGrammar::import` to confirm schema fidelity. Exits non-zero on any failure in the pipeline.

### Benchmark results

This PR is a new subsystem rather than a perf optimization, so the standard benchmark table is degenerate (no upstream baseline). Per-invocation timing on the test fixture:

```
CPU:   AMD Ryzen 9 9950X3D2 (16C/32T)
RAM:   64 GB DDR5-6000
OS:    Windows 11 Pro 26200
Build: MSVC 19.x, /O2 /MD Release, MSBuild
```

| Stage | Time |
|---|---|
| cube.obj load (tinyobjloader) | <1 ms |
| Build half-edge mesh | <1 ms |
| Extract types | <1 ms |
| Write seed grammar JSON | <1 ms |
| GraphGrammar::import round-trip | <1 ms |

The cube is intentionally small so the smoke test stays fast. The same pipeline scales to meshes with thousands of faces in under a second on this hardware.

## Notes for the maintainer

- The cube fixture is the only new asset, ~30 lines. No large binaries.
- All `mesh_extraction::` functions take an optional `std::string* error` out-parameter so callers can surface validation failures without exceptions.
- If you'd like to split this into "library + vcxproj wiring" and "CLI + fixture" PRs, happy to do so — they're independent commits within the same change.
