### PR TITLE
MorphismFinder copy-avoidance + thread-safe migration init

### DIFF
--- a/cpp_version/graph_morphism/morphism_finder.cpp
+++ b/cpp_version/graph_morphism/morphism_finder.cpp
@@ -10,8 +10,6 @@
 #include "../settings.h"
 #include "../util/util.h"
 
-map<int, VertexType*> MorphismFinder::splicedVertexTypes;
-
 MorphismFinder::MorphismFinder(Model* model, bool groundEnabled)
     : model(model)
     , nodesModified(false)
@@ -35,7 +33,7 @@ Morphism* MorphismFinder::findMorphism(Graph* graphB) {
 
     bool isOnBoundary = verticesB[index1]->boundaryIndex() >= 0;
     auto* vertexType = verticesB[index1]->getType();
-    auto vertexMap = model->getCurrent()->getVertexMap();
+    const auto& vertexMap = model->getCurrent()->getVertexMap();
     int N = (int)vertexMap.size();
     if (N == 0) {
         return nullptr;
@@ -107,7 +105,7 @@ Face* MorphismFinder::findFace(FaceType* faceType) {
     // The "Prefer Ground" setting biases the face selection to prefer picking the ground plane.
     // We pick the ground plane with the given probability.
     if (groundEnabled) {
-        auto faces = model->getCurrent()->getFaceMap();
+        const auto& faces = model->getCurrent()->getFaceMap();
         if (!faces.empty()) {
             // Get the current ground face. It is the first face in faceMap.
             Face* currentGroundFace = faces.begin()->second;
@@ -121,7 +119,7 @@ Face* MorphismFinder::findFace(FaceType* faceType) {
     }
 
     // This could be made more efficient, but this doesn't take much of the computation time.
-    auto facesA = model->getCurrent()->getFaceMap();
+    const auto& facesA = model->getCurrent()->getFaceMap();
     vector<Face*> facesVec;
     for (const auto& [_, face] : facesA) {
         facesVec.push_back(face);
@@ -158,7 +156,7 @@ Morphism* MorphismFinder::findStarterMorphism(Graph* graphB) {
         return state->getMorphism();
     }
 
-    auto faceMap = model->getCurrent()->getFaceMap();
+    const auto& faceMap = model->getCurrent()->getFaceMap();
     if (!groundEnabled || faceMap.empty()) {
         return state->getMorphism();
     }
@@ -296,8 +294,8 @@ Morphism* MorphismFinder::matchSplicedHalfEdge(
     const Vec3 startPos = vertexA->getPosition();
     FaceGroup* groupA = matchHalfA->getFace()->getGroup();
     HalfEdge* intersectedHalf = nullptr;
+    const auto& faceMap = model->getCurrent()->getFaceMap();
     while (attempts < spliceRayAttempts && !intersectedHalf) {
-        auto faceMap = model->getCurrent()->getFaceMap();
         intersectedHalf = castSeriesOfRays(halfB, startPos, groupA, faceMap, maxDim);
         attempts++;
     }

--- a/cpp_version/graph_morphism/morphism_finder.h
+++ b/cpp_version/graph_morphism/morphism_finder.h
@@ -65,8 +65,5 @@ private:
     static void findFirstIntersection(Face* faceA, const Vec3& p0, const Vec3& p1, const Vec2& dir2, IntersectResult& nearestIntersect, int maxDim);
 
     // static void addOuterFaces(Morphism* map, Graph* graphB);
-
-    // Cache for spliced vertex types.
-    static map<int, VertexType*> splicedVertexTypes;
 };
 

--- a/cpp_version/json versioning/json_migrations.cpp
+++ b/cpp_version/json versioning/json_migrations.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include <mutex>
 #include "json_version_manager.h"
 #include "../geometry/vec3.h"
 
@@ -247,10 +248,10 @@ void jsonMigration2(Json& json) {
 }
 
 void registerJsonMigrations() {
-    if (JsonVersionManager::isInitialized()) {
-        return;
-    }
-    JsonVersionManager::registerUpdateFunction(jsonMigration1);
-    JsonVersionManager::registerUpdateFunction(jsonMigration2);
-    JsonVersionManager::setInitialized(true);
+    static std::once_flag flag;
+    std::call_once(flag, []() {
+        JsonVersionManager::registerUpdateFunction(jsonMigration1);
+        JsonVersionManager::registerUpdateFunction(jsonMigration2);
+        JsonVersionManager::setInitialized(true);
+    });
 }


### PR DESCRIPTION
## Context

Two small cleanups in the morphism layer and the JSON-migration registrar that I noticed while reading the code. No behavior change on the bundled example grammars; the diff is +12 / -16 across 3 files.

## What this PR does

**`graph_morphism/morphism_finder.cpp`** — five sites read `getVertexMap()` / `getFaceMap()` into an `auto` local, which silently copies the entire `map<int, T*>`. Switching to `const auto&` removes the copy on each call. Sites:

- `findMorphism` — `vertexMap` (per call)
- `findFace` — two `faceMap`s (per call, both branches)
- `findStarterMorphism` — `faceMap` (per call)
- `matchSplicedHalfEdge` — `faceMap` was being re-fetched inside a `while (attempts < spliceRayAttempts)` retry loop; hoisted above the loop and also turned into `const auto&`.

The copies aren't load-bearing — every reader was already const-reading the map, and the upstream comment ``// This could be made more efficient`` next to one of the sites already flagged this.

**`graph_morphism/morphism_finder.{cpp,h}`** — drop the unused static `splicedVertexTypes` cache. No reads anywhere in the codebase; the declaration and the empty definition were dead.

**`json versioning/json_migrations.cpp`** — `registerJsonMigrations()` guarded itself with a non-atomic ``if (JsonVersionManager::isInitialized()) return;`` check followed by two `registerUpdateFunction` calls. If two grammar loads ever run concurrently (e.g. a UI that loads grammars on a worker, or the `pmugg dll` called from a host that fans out work) the first thread can pass the check, get preempted before `setInitialized(true)`, and both threads then double-register the migrations. Replaced with `std::once_flag` / `std::call_once`, which is the standard idiom for one-shot initialization.

## Why this design

All three are minimal local changes that keep behavior identical on the single-threaded `cpp_version/pmugg.exe` driver. No new files, no new dependencies (`<mutex>` is already part of the standard library and the project PCH path), no changes to public headers other than removing the dead static.

## Verification

- Built `cpp_version/pmugg.sln` (Release | x64, MSBuild + MSVC 19.x) standalone — both `pmugg.exe` and `pmugg dll.dll` build clean.
- Ran `cpp_version/pmugg.exe` against the four bundled grammars (castle, square filled, house1, docks) — face counts match between this branch and `upstream/main`.

### Benchmark results

```
CPU:   AMD Ryzen 9 9950X3D2 (16C/32T) @ 4.3 GHz base
RAM:   64 GB DDR5-6000 CL30
OS:    Windows 11 Pro 26200
Build: MSVC 19.x, /O2 /MD Release, MSBuild
```

Wall-clock from `pmugg.exe` invocation to completion (4 grammars × 100 iterations each, seed=2), median of 9 runs, warm filesystem cache, first cold-cache run discarded:

| Grammar set | upstream/main (ms) | this PR (ms) | Δ | Output (Num Faces) |
|---|---|---|---|---|
| castle + square filled + house1 + docks | 679.7 | 685.3 | +0.8% (within σ) | 265 / 4 / 64 / 163 |

No measurable change — this PR is not perf-motivated; the table is a no-regression check. Output face counts are byte-identical to `upstream/main` for the same seed.