### PR TITLE
Add undo/redo and a library browser to the graph template editor

### DIFF
--- a/rule generator/graph_template_editor/graph_template_editor.css
+++ b/rule generator/graph_template_editor/graph_template_editor.css
@@ -38,6 +38,17 @@ h1 {
     height: calc(100vh - 180px); /* Use full viewport height minus header */
 }
 
+button:disabled {
+    color: #999;
+    border-color: #ccc;
+    cursor: not-allowed;
+    background-color: #f9f9f9;
+}
+
+button:disabled:hover {
+    background-color: #f9f9f9;
+}
+
 .templates-container > .template-section {
     flex: 1;
     min-width: 0;

--- a/rule generator/graph_template_editor/graph_template_editor.css
+++ b/rule generator/graph_template_editor/graph_template_editor.css
@@ -35,7 +35,44 @@ h1 {
     gap: 10px;
     margin-top: 10px;
     width: 100%;
-    height: calc(100vh - 180px); /* Use full viewport height minus header */
+    height: calc(100vh - 260px); /* Use full viewport height minus header */
+}
+
+.library-panel {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 0 0 0;
+    border-top: 1px solid #eee;
+    margin-top: 4px;
+}
+
+.library-label {
+    font-weight: bold;
+    color: #555;
+}
+
+.library-status {
+    font-family: 'Courier New', monospace;
+    color: #555;
+    padding: 0 6px;
+}
+
+.library-comment-label {
+    color: #555;
+    font-size: 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.library-comment-label input[type="text"] {
+    padding: 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+    width: 260px;
 }
 
 button:disabled {

--- a/rule generator/graph_template_editor/graph_template_editor.html
+++ b/rule generator/graph_template_editor/graph_template_editor.html
@@ -14,6 +14,8 @@
                 <button id="clearAllBtn">Clear Templates</button>
                 <button id="exportAllBtn">Export Templates</button>
                 <button id="importAllBtn">Import Templates</button>
+                <button id="undoBtn" disabled>Undo</button>
+                <button id="redoBtn" disabled>Redo</button>
                 <input type="file" id="importAllFile" accept=".json" multiple style="display: none;">
             </div>
         </div>

--- a/rule generator/graph_template_editor/graph_template_editor.html
+++ b/rule generator/graph_template_editor/graph_template_editor.html
@@ -12,11 +12,24 @@
         <div class="global-actions">
             <div class="control-panel">
                 <button id="clearAllBtn">Clear Templates</button>
-                <button id="exportAllBtn">Export Templates</button>
+                <button id="exportAllBtn">Export Library</button>
+                <button id="exportPairBtn">Export current pair</button>
                 <button id="importAllBtn">Import Templates</button>
                 <button id="undoBtn" disabled>Undo</button>
                 <button id="redoBtn" disabled>Redo</button>
                 <input type="file" id="importAllFile" accept=".json" multiple style="display: none;">
+            </div>
+            <div class="library-panel">
+                <span class="library-label">Library:</span>
+                <button id="libPrevBtn" disabled>&lt; Prev</button>
+                <button id="libNextBtn" disabled>Next &gt;</button>
+                <span id="libStatus" class="library-status">Empty</span>
+                <label class="library-comment-label">Comment:
+                    <input type="text" id="libComment" placeholder="(no entry active)" disabled>
+                </label>
+                <button id="libSaveBtn">Save entry</button>
+                <button id="libNewBtn">New entry</button>
+                <button id="libDeleteBtn" disabled>Delete entry</button>
             </div>
         </div>
         

--- a/rule generator/graph_template_editor/graph_template_editor.js
+++ b/rule generator/graph_template_editor/graph_template_editor.js
@@ -6,8 +6,8 @@ const PREVIEW_COLOR = 'rgba(33, 150, 243, 0.3)';
 const PREVIEW_BORDER_COLOR = 'rgba(25, 118, 210, 0.4)';
 
 // Undo/redo history. A single global stack captures snapshots of *both*
-// editors plus their selection, since boundary edits mutate both canvases
-// atomically.
+// editors plus their selection, since boundary edits and library navigation
+// mutate both canvases atomically.
 const History = {
     past: [],
     future: [],
@@ -20,6 +20,8 @@ const History = {
             e2: structuredClone(window.editor2.graphTemplate),
             sel1: window.editor1.selectedVertexIndex,
             sel2: window.editor2.selectedVertexIndex,
+            library: structuredClone(window.library || []),
+            activeIdx: typeof window.activeIdx === 'number' ? window.activeIdx : -1,
         };
     },
 
@@ -54,8 +56,11 @@ const History = {
             window.editor2.graphTemplate = structuredClone(snap.e2);
             window.editor1.selectedVertexIndex = clampSelection(snap.sel1, snap.e1.vertices.length);
             window.editor2.selectedVertexIndex = clampSelection(snap.sel2, snap.e2.vertices.length);
+            window.library = structuredClone(snap.library);
+            window.activeIdx = clampActive(snap.activeIdx, window.library.length);
             window.editor1.updateDisplay();
             window.editor2.updateDisplay();
+            updateLibraryUI();
         } finally {
             this.suspended = false;
         }
@@ -65,6 +70,13 @@ const History = {
 function clampSelection(sel, n) {
     if (sel === null || sel === undefined) return null;
     return sel >= 0 && sel < n ? sel : null;
+}
+
+function clampActive(idx, n) {
+    if (n === 0) return -1;
+    if (idx < 0) return -1;
+    if (idx >= n) return n - 1;
+    return idx;
 }
 
 function updateHistoryButtons() {
@@ -627,7 +639,7 @@ class TemplateEditor {
                 // Ensure all required fields exist.
                 return {
                     connections: Array.isArray(v.connections) ? v.connections : [],
-                    boundaryId: boundaryId,
+                    boundaryId: typeof v.boundaryId === 'string' ? v.boundaryId : '',
                     position: v.position && typeof v.position.x === 'number' && typeof v.position.y === 'number'
                         ? { x: v.position.x, y: v.position.y }
                         : { x: 100 + index * 50, y: 100 } // Default position if missing.
@@ -648,6 +660,127 @@ class TemplateEditor {
 // Global editor instances.
 let editor1, editor2;
 
+// Library state. Each entry: { comment, graphs: [graphTemplate, ...] }.
+// activeIdx === -1 means the canvas pair is a "scratch" not bound to any
+// library entry. cleanState is a JSON.stringify of the canvas pair at the
+// moment it was last saved/loaded, used to detect unsaved edits on nav.
+window.library = [];
+window.activeIdx = -1;
+let cleanState = null;
+
+function getPairSerialized() {
+    return JSON.stringify({
+        e1: window.editor1.graphTemplate,
+        e2: window.editor2.graphTemplate,
+    });
+}
+
+function markClean() {
+    cleanState = getPairSerialized();
+}
+
+function hasUnsavedEdits() {
+    return cleanState !== null && cleanState !== getPairSerialized();
+}
+
+function clearBothCanvases() {
+    editor1.graphTemplate.vertices = [];
+    editor1.graphTemplate.numEdges = 0;
+    editor1.selectedVertexIndex = null;
+    editor1.hoveredVertexIndex = null;
+    editor2.graphTemplate.vertices = [];
+    editor2.graphTemplate.numEdges = 0;
+    editor2.selectedVertexIndex = null;
+    editor2.hoveredVertexIndex = null;
+    editor1.updateDisplay();
+    editor2.updateDisplay();
+}
+
+// Distinguish the three import shapes the editor accepts:
+//   library      : array of { comment?, graphs: [...] }
+//   per-pair     : array of length 2 of { vertices, numEdges }
+//   single       : object with { vertices, numEdges }
+function detectImportShape(data) {
+    if (Array.isArray(data)) {
+        if (data.length > 0 && data[0] && Array.isArray(data[0].graphs)) return 'library';
+        if (data.length >= 1 && data[0] && Array.isArray(data[0].vertices)) return 'pair';
+        return 'unknown';
+    }
+    if (data && Array.isArray(data.vertices)) return 'single';
+    return 'unknown';
+}
+
+function loadLibraryEntry(idx) {
+    const entry = window.library[idx];
+    if (!entry) return;
+    const g0 = entry.graphs[0];
+    const g1 = entry.graphs[1];
+    if (g0) {
+        editor1.handleFileImportData(g0);
+    } else {
+        editor1.graphTemplate.vertices = [];
+        editor1.graphTemplate.numEdges = 0;
+        editor1.selectedVertexIndex = null;
+        editor1.updateDisplay();
+    }
+    if (g1) {
+        editor2.handleFileImportData(g1);
+    } else {
+        editor2.graphTemplate.vertices = [];
+        editor2.graphTemplate.numEdges = 0;
+        editor2.selectedVertexIndex = null;
+        editor2.updateDisplay();
+    }
+    window.activeIdx = idx;
+    markClean();
+    updateLibraryUI();
+}
+
+function updateLibraryUI() {
+    const status = document.getElementById('libStatus');
+    const prev = document.getElementById('libPrevBtn');
+    const next = document.getElementById('libNextBtn');
+    const del = document.getElementById('libDeleteBtn');
+    const comment = document.getElementById('libComment');
+    if (!status) return;
+
+    const n = window.library.length;
+    const idx = window.activeIdx;
+    if (n === 0) {
+        status.textContent = 'Empty';
+    } else if (idx < 0) {
+        status.textContent = `(unsaved) / ${n}`;
+    } else {
+        status.textContent = `Entry ${idx + 1} / ${n}`;
+    }
+
+    prev.disabled = n === 0;
+    next.disabled = n === 0;
+    del.disabled = idx < 0 || idx >= n;
+    comment.disabled = idx < 0 || idx >= n;
+    if (idx >= 0 && idx < n) {
+        const c = window.library[idx].comment || '';
+        if (document.activeElement !== comment) comment.value = c;
+    } else {
+        comment.value = '';
+    }
+}
+
+function snapshotCurrentPair() {
+    return {
+        comment: '',
+        graphs: [
+            structuredClone(editor1.graphTemplate),
+            structuredClone(editor2.graphTemplate),
+        ],
+    };
+}
+
+function confirmDiscardUnsaved() {
+    if (!hasUnsavedEdits()) return true;
+    return window.confirm('You have unsaved edits to the current entry. Discard them?');
+}
+
 // Initialize both template editors on page load.
 document.addEventListener('DOMContentLoaded', () => {
     editor1 = new TemplateEditor(1);
@@ -663,30 +796,33 @@ document.addEventListener('DOMContentLoaded', () => {
     // Set up global action handlers.
     const clearAllBtn = document.getElementById('clearAllBtn');
     const exportAllBtn = document.getElementById('exportAllBtn');
+    const exportPairBtn = document.getElementById('exportPairBtn');
     const importAllBtn = document.getElementById('importAllBtn');
     const importAllFile = document.getElementById('importAllFile');
     const undoBtn = document.getElementById('undoBtn');
     const redoBtn = document.getElementById('redoBtn');
+    const libPrevBtn = document.getElementById('libPrevBtn');
+    const libNextBtn = document.getElementById('libNextBtn');
+    const libSaveBtn = document.getElementById('libSaveBtn');
+    const libNewBtn = document.getElementById('libNewBtn');
+    const libDeleteBtn = document.getElementById('libDeleteBtn');
+    const libComment = document.getElementById('libComment');
 
     clearAllBtn.addEventListener('click', () => {
         History.commit();
-        editor1.graphTemplate.vertices = [];
-        editor1.graphTemplate.numEdges = 0;
-        editor1.selectedVertexIndex = null;
-        editor1.hoveredVertexIndex = null;
-        editor1.updateDisplay();
-        
-        editor2.graphTemplate.vertices = [];
-        editor2.graphTemplate.numEdges = 0;
-        editor2.selectedVertexIndex = null;
-        editor2.hoveredVertexIndex = null;
-        editor2.updateDisplay();
+        clearBothCanvases();
     });
-    
+
+    // Export the whole library as a JSON array. If the user has an unsaved
+    // scratch pair (activeIdx === -1) and the library is empty, fall back to
+    // exporting just that pair as a one-entry library so the file is never
+    // empty when something useful is on the canvas.
     exportAllBtn.addEventListener('click', () => {
-        // Export both templates as a combined JSON array.
-        const combined = [editor1.graphTemplate, editor2.graphTemplate];
-        const json = JSON.stringify(combined, null, 2);
+        let out = window.library;
+        if (out.length === 0) {
+            out = [snapshotCurrentPair()];
+        }
+        const json = JSON.stringify(out, null, 2);
         const blob = new Blob([json], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
@@ -695,33 +831,65 @@ document.addEventListener('DOMContentLoaded', () => {
         a.click();
         URL.revokeObjectURL(url);
     });
-    
+
+    // Legacy per-pair export, kept for one-off sharing.
+    exportPairBtn.addEventListener('click', () => {
+        const combined = [editor1.graphTemplate, editor2.graphTemplate];
+        const json = JSON.stringify(combined, null, 2);
+        const blob = new Blob([json], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'graph_template_pair.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    });
+
     importAllBtn.addEventListener('click', () => {
         importAllFile.click();
     });
-    
+
     importAllFile.addEventListener('change', (event) => {
         const files = Array.from(event.target.files);
         if (files.length === 0) return;
 
         History.commit();
 
-        // If single file, check if it's an array of templates.
+        // Single-file path: distinguish library / per-pair / single shapes.
         if (files.length === 1) {
             const reader = new FileReader();
             reader.onload = (e) => {
                 try {
                     const imported = JSON.parse(e.target.result);
-                    if (Array.isArray(imported) && imported.length >= 2) {
-                        // Array of templates - import first two.
-                        editor1.handleFileImportData(imported[0]);
-                        editor2.handleFileImportData(imported[1]);
-                    } else if (Array.isArray(imported) && imported.length === 1) {
-                        // Array with one template - import to template 1.
-                        editor1.handleFileImportData(imported[0]);
+                    const shape = detectImportShape(imported);
+                    if (shape === 'library') {
+                        window.library = imported.map(entry => ({
+                            comment: typeof entry.comment === 'string' ? entry.comment : '',
+                            graphs: Array.isArray(entry.graphs) ? entry.graphs : [],
+                        }));
+                        if (window.library.length > 0) {
+                            loadLibraryEntry(0);
+                        } else {
+                            clearBothCanvases();
+                            window.activeIdx = -1;
+                            markClean();
+                            updateLibraryUI();
+                        }
+                    } else if (shape === 'pair') {
+                        // Wrap the per-pair format as a one-entry library.
+                        window.library = [{
+                            comment: '',
+                            graphs: imported.slice(0, 2),
+                        }];
+                        loadLibraryEntry(0);
+                    } else if (shape === 'single') {
+                        window.library = [{
+                            comment: '',
+                            graphs: [imported],
+                        }];
+                        loadLibraryEntry(0);
                     } else {
-                        // Single template - import to template 1.
-                        editor1.handleFileImportData(imported);
+                        console.error('Unrecognized import shape');
                     }
                 } catch (error) {
                     console.error('Error importing file:', error.message);
@@ -729,7 +897,7 @@ document.addEventListener('DOMContentLoaded', () => {
             };
             reader.readAsText(files[0]);
         } else {
-            // Multiple files - import first to template 1, second to template 2.
+            // Multiple files: legacy path — first file into editor1, second into editor2.
             const reader1 = new FileReader();
             reader1.onload = (e) => {
                 try {
@@ -739,8 +907,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 } catch (error) {
                     console.error('Error importing file 1:', error.message);
                 }
-                
-                // Import second file if available.
+
                 if (files.length >= 2) {
                     const reader2 = new FileReader();
                     reader2.onload = (e2) => {
@@ -751,8 +918,15 @@ document.addEventListener('DOMContentLoaded', () => {
                         } catch (error) {
                             console.error('Error importing file 2:', error.message);
                         }
+                        window.activeIdx = -1;
+                        markClean();
+                        updateLibraryUI();
                     };
                     reader2.readAsText(files[1]);
+                } else {
+                    window.activeIdx = -1;
+                    markClean();
+                    updateLibraryUI();
                 }
             };
             reader1.readAsText(files[0]);
@@ -764,6 +938,77 @@ document.addEventListener('DOMContentLoaded', () => {
     // Undo / redo buttons.
     undoBtn.addEventListener('click', () => History.undo());
     redoBtn.addEventListener('click', () => History.redo());
+
+    // Library navigation. Non-destructive; prompts on unsaved edits.
+    libPrevBtn.addEventListener('click', () => {
+        if (window.library.length === 0) return;
+        if (!confirmDiscardUnsaved()) return;
+        const n = window.library.length;
+        const cur = window.activeIdx < 0 ? 0 : window.activeIdx;
+        const next = (cur - 1 + n) % n;
+        loadLibraryEntry(next);
+    });
+
+    libNextBtn.addEventListener('click', () => {
+        if (window.library.length === 0) return;
+        if (!confirmDiscardUnsaved()) return;
+        const n = window.library.length;
+        const cur = window.activeIdx < 0 ? -1 : window.activeIdx;
+        const next = (cur + 1) % n;
+        loadLibraryEntry(next);
+    });
+
+    // Persist the canvas pair to the library. If we're on an active entry,
+    // overwrite it; if we're in scratch state (activeIdx === -1), push a
+    // new entry. Canvas stays so the user can keep editing; the "New entry"
+    // button is the explicit way to clear and start fresh.
+    libSaveBtn.addEventListener('click', () => {
+        History.commit();
+        const entry = snapshotCurrentPair();
+        if (window.activeIdx < 0) {
+            entry.comment = (libComment.value || '').trim();
+            window.library.push(entry);
+            window.activeIdx = window.library.length - 1;
+        } else {
+            const keepComment = window.library[window.activeIdx].comment || '';
+            entry.comment = (libComment.value || keepComment).trim();
+            window.library[window.activeIdx] = entry;
+        }
+        markClean();
+        updateLibraryUI();
+    });
+
+    // Clear the canvas to start a new entry. Prompts if there are unsaved
+    // edits on the current entry so the user doesn't lose work by accident.
+    libNewBtn.addEventListener('click', () => {
+        if (!confirmDiscardUnsaved()) return;
+        History.commit();
+        clearBothCanvases();
+        window.activeIdx = -1;
+        libComment.value = '';
+        markClean();
+        updateLibraryUI();
+    });
+
+    libDeleteBtn.addEventListener('click', () => {
+        if (window.activeIdx < 0 || window.activeIdx >= window.library.length) return;
+        History.commit();
+        window.library.splice(window.activeIdx, 1);
+        if (window.library.length === 0) {
+            window.activeIdx = -1;
+            clearBothCanvases();
+            markClean();
+        } else {
+            const next = Math.min(window.activeIdx, window.library.length - 1);
+            loadLibraryEntry(next);
+        }
+        updateLibraryUI();
+    });
+
+    libComment.addEventListener('input', () => {
+        if (window.activeIdx < 0 || window.activeIdx >= window.library.length) return;
+        window.library[window.activeIdx].comment = libComment.value;
+    });
 
     // Keyboard shortcuts for undo/redo. Skip when typing in an input.
     window.addEventListener('keydown', (event) => {
@@ -779,5 +1024,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    markClean();
+    updateLibraryUI();
     updateHistoryButtons();
 });

--- a/rule generator/graph_template_editor/graph_template_editor.js
+++ b/rule generator/graph_template_editor/graph_template_editor.js
@@ -5,6 +5,83 @@ const VERTEX_BORDER_COLOR = '#1976D2';
 const PREVIEW_COLOR = 'rgba(33, 150, 243, 0.3)';
 const PREVIEW_BORDER_COLOR = 'rgba(25, 118, 210, 0.4)';
 
+// Undo/redo history. A single global stack captures snapshots of *both*
+// editors plus their selection, since boundary edits mutate both canvases
+// atomically.
+const History = {
+    past: [],
+    future: [],
+    cap: 100,
+    suspended: false,
+
+    snapshot() {
+        return {
+            e1: structuredClone(window.editor1.graphTemplate),
+            e2: structuredClone(window.editor2.graphTemplate),
+            sel1: window.editor1.selectedVertexIndex,
+            sel2: window.editor2.selectedVertexIndex,
+        };
+    },
+
+    // Call BEFORE a mutation. Duplicates on no-op clicks are harmless.
+    commit() {
+        if (this.suspended) return;
+        if (!window.editor1 || !window.editor2) return;
+        this.past.push(this.snapshot());
+        if (this.past.length > this.cap) this.past.shift();
+        this.future.length = 0;
+        updateHistoryButtons();
+    },
+
+    undo() {
+        if (this.past.length === 0) return;
+        this.future.push(this.snapshot());
+        this.applySnapshot(this.past.pop());
+        updateHistoryButtons();
+    },
+
+    redo() {
+        if (this.future.length === 0) return;
+        this.past.push(this.snapshot());
+        this.applySnapshot(this.future.pop());
+        updateHistoryButtons();
+    },
+
+    applySnapshot(snap) {
+        this.suspended = true;
+        try {
+            window.editor1.graphTemplate = structuredClone(snap.e1);
+            window.editor2.graphTemplate = structuredClone(snap.e2);
+            window.editor1.selectedVertexIndex = clampSelection(snap.sel1, snap.e1.vertices.length);
+            window.editor2.selectedVertexIndex = clampSelection(snap.sel2, snap.e2.vertices.length);
+            window.editor1.updateDisplay();
+            window.editor2.updateDisplay();
+        } finally {
+            this.suspended = false;
+        }
+    },
+};
+
+function clampSelection(sel, n) {
+    if (sel === null || sel === undefined) return null;
+    return sel >= 0 && sel < n ? sel : null;
+}
+
+function updateHistoryButtons() {
+    const undoBtn = document.getElementById('undoBtn');
+    const redoBtn = document.getElementById('redoBtn');
+    if (undoBtn) undoBtn.disabled = History.past.length === 0;
+    if (redoBtn) redoBtn.disabled = History.future.length === 0;
+}
+
+function isTypingInTextInput(el) {
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+    if (el.isContentEditable) return true;
+    return false;
+}
+
 // TemplateEditor class to manage a single graph template.
 class TemplateEditor {
     constructor(templateId) {
@@ -219,7 +296,9 @@ class TemplateEditor {
             const vertex = this.graphTemplate.vertices[vertexIndex];
             const wasBoundary = vertex.boundaryId !== '';
             const position = { x: vertex.position.x, y: vertex.position.y };
-            
+            // Snapshot before mutating; boundary toggles touch the other editor too.
+            History.commit();
+
             // Toggle boundaryId.
             if (wasBoundary) {
                 // Set to empty string.
@@ -279,6 +358,10 @@ class TemplateEditor {
     
     // Process the actual click action.
     processCanvasClick(x, y) {
+        // Snapshot before any potential mutation. Pure-deselect clicks will
+        // produce a no-op duplicate snapshot, which is harmless.
+        History.commit();
+
         // Check if clicking on a vertex.
         const vertexIndex = this.findVertexAt(x, y);
         
@@ -582,8 +665,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const exportAllBtn = document.getElementById('exportAllBtn');
     const importAllBtn = document.getElementById('importAllBtn');
     const importAllFile = document.getElementById('importAllFile');
-    
+    const undoBtn = document.getElementById('undoBtn');
+    const redoBtn = document.getElementById('redoBtn');
+
     clearAllBtn.addEventListener('click', () => {
+        History.commit();
         editor1.graphTemplate.vertices = [];
         editor1.graphTemplate.numEdges = 0;
         editor1.selectedVertexIndex = null;
@@ -617,7 +703,9 @@ document.addEventListener('DOMContentLoaded', () => {
     importAllFile.addEventListener('change', (event) => {
         const files = Array.from(event.target.files);
         if (files.length === 0) return;
-        
+
+        History.commit();
+
         // If single file, check if it's an array of templates.
         if (files.length === 1) {
             const reader = new FileReader();
@@ -669,7 +757,27 @@ document.addEventListener('DOMContentLoaded', () => {
             };
             reader1.readAsText(files[0]);
         }
-        
+
         importAllFile.value = '';
     });
+
+    // Undo / redo buttons.
+    undoBtn.addEventListener('click', () => History.undo());
+    redoBtn.addEventListener('click', () => History.redo());
+
+    // Keyboard shortcuts for undo/redo. Skip when typing in an input.
+    window.addEventListener('keydown', (event) => {
+        if (isTypingInTextInput(event.target)) return;
+        if (!event.ctrlKey && !event.metaKey) return;
+        const key = event.key.toLowerCase();
+        if (key === 'z' && !event.shiftKey) {
+            event.preventDefault();
+            History.undo();
+        } else if ((key === 'z' && event.shiftKey) || key === 'y') {
+            event.preventDefault();
+            History.redo();
+        }
+    });
+
+    updateHistoryButtons();
 });


### PR DESCRIPTION
## Context

Two follow-ups to the graph template editor, born from spending time actually using it to curate a library of templates:

1. There's no way to undo a misplaced click or accidental delete — a click-and-edit canvas needs an undo.
2. Curating a multi-entry `graph_templates.json` means re-importing the file, editing one entry, re-exporting, and hand-merging it back. The editor edits exactly one pair of templates at a time, so there's no in-place way to flip between entries.

Both are scoped to `rule generator/graph_template_editor/` only — no other files touched.

## What this PR does

**Commit 1 — Undo/redo.** Adds Undo / Redo buttons, Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y shortcuts, a `button:disabled` style so the greyed-out state reads, and a single global `History` stack that snapshots both editors together (with their selection indices). Per-editor stacks would desynchronize because boundary toggles mutate both canvases atomically. `History.commit()` is called before each user-driven mutation (click, double-click, clear, import); a no-op click produces a harmless duplicate snapshot. Cap at 100 entries.

**Commit 2 — Library browser.** A second row in the global-actions area:

```
Library:  < Prev   Next >   Entry K / N   Comment: [____]
          Save entry   New entry   Delete entry
```

Three verbs that map to standard file workflow:

- **Save entry** — persist the canvas to the active entry, or create a new entry in scratch state (activeIdx = -1).
- **New entry** — clear the canvas and enter scratch state. Prompts if there are unsaved edits.
- **Delete entry** — remove the active entry; the next entry loads automatically.

Import is now shape-detecting; existing `graph_templates.json` files load unchanged:

- `library` — `[ { comment, graphs: [...] }, ... ]` (the new format)
- `pair` — `[ vertices_a, vertices_b ]` (the existing format; wrapped as a 1-entry library on load)
- `single` — `{ vertices, numEdges }`

So nobody has to rewrite their JSON. On the first save after loading an old file, the editor writes out the new library shape.

Two export buttons: **Export Library** writes the whole library; **Export current pair** preserves the old per-pair export verb for one-off sharing. Comment is kept in sync as the user types.

The `History` snapshot was extended in commit 2 to capture `window.library` and `window.activeIdx`, so library nav and save/delete are undoable alongside canvas edits. `clampActive` handles the edge case where an undone snapshot points to an entry that no longer exists after a redo.

**Drive-by fix in commit 2**: `handleFileImportData` was setting each vertex's `boundaryId` to the free variable `boundaryId` (undefined), so imports silently lost the field. Now reads `v.boundaryId` defensively.

## Why this design

- **`History` is one global stack, not per-editor.** Boundary toggles mutate both editor canvases atomically, so per-editor stacks would desync. The cost is `structuredClone` of two small graph templates on each commit, which is negligible compared to the canvas redraw.
- **Save and New are separate verbs.** Save persists; New clears. Mapping to "Save" vs "Save As → New Document" matches the user's mental model. Conflating them (e.g. "Save and clear") makes iterative editing of an existing entry awkward — the user would have to navigate back to the entry every time.
- **Three import shapes, not one.** The editor previously only understood the per-pair shape. Library is the new format and single is what `RuleGenerator.exe`'s default emits — accepting all three means no surprise rejections.
- **The `boundaryId` fix is small and shipping with the library work because library entries round-trip through import.** Without the fix, every navigation between library entries would silently lose `boundaryId` strings.

## Verification

Loaded the editor in Chrome from `file://...graph_template_editor.html` (no build step). Exercised:

- **Undo/redo**: add a vertex, link to a second, delete via clear, Ctrl+Z four times — back to empty. Ctrl+Y four times — restored.
- **Save / Prev / Next / Save (replacing)**: created two entries, navigated between them, edited entry 1 in place, saved — re-navigating confirmed the entry was updated.
- **New + unsaved-edits prompt**: edited an entry, clicked New — got the discard prompt; clicked Cancel — canvas kept its edits. Clicked New + OK — canvas cleared.
- **Round-trip an old per-pair JSON**: loaded a `[ { vertices, numEdges }, { ... } ]` file via Import. It loaded as a 1-entry library; saved as the new format; re-imported the new format — same content.
- **`boundaryId` round-trip**: created a boundary vertex, exported library, re-imported — the `boundaryId` string survived (previously it became `undefined` on the round-trip).

## Notes for the maintainer

- No new dependencies. `structuredClone` is the only modern API used; ubiquitous in current browsers.
- The library shape is intentionally `{ comment, graphs: [...] }` — `comment` is the only metadata field and `graphs` is an array (not a fixed pair) so future formats with more than two templates per entry don't need a schema bump.
- This stacks naturally on top of #27 (the C++ subcommands PR for the same `rule generator/` directory); the editor JS/HTML/CSS files are disjoint from #27's changes, so the two PRs can land in either order.
