### PR TITLE
Add boundary half-edges. Fix half-edges forward in RuleGenerator

### DIFF
--- a/cpp_version/graph/graph.cpp
+++ b/cpp_version/graph/graph.cpp
@@ -453,6 +453,10 @@ void Graph::setBVertices(const vector<GraphVertex*>& verts) {
     bVertices = verts;
 }
 
+void Graph::setBHalfEdges(const vector<GraphHalfEdge*>& halfs) {
+    bHalfEdges = halfs;
+}
+
 void Graph::merge(Graph* other) {
     if (!other || other == this) {
         return;

--- a/cpp_version/graph/graph.h
+++ b/cpp_version/graph/graph.h
@@ -57,6 +57,7 @@ public:
     Graph* copy() const;
     void merge(Graph* other);
     void setBVertices(const vector<GraphVertex*>& verts);
+    void setBHalfEdges(const vector<GraphHalfEdge*>& halfs);
 
 private:
     vector<GraphVertex*> vertices;

--- a/rule generator/RuleGenerator/RuleExporter.cpp
+++ b/rule generator/RuleGenerator/RuleExporter.cpp
@@ -54,11 +54,8 @@ void updateBoundaryVertices(Graph* graph) {
 	graph->setBVertices(bVertices);
 }
 
-GraphHalfEdge* boundaryHalfForBVertex(GraphVertex* bVertex) {
-	if (!bVertex) {
-		return nullptr;
-	}
-	for (auto* half : bVertex->getHalfEdges()) {
+GraphHalfEdge* findBoundaryHalfEdge(const vector<GraphHalfEdge*>& halfEdges) {
+	for (auto* half : halfEdges) {
 		if (half && !half->getEdge()) {
 			return half;
 		}
@@ -69,9 +66,9 @@ GraphHalfEdge* boundaryHalfForBVertex(GraphVertex* bVertex) {
 void updateBoundaryHalfEdges(Graph* graph) {
 	vector<GraphHalfEdge*> bHalfEdges;
 	for (auto* bVertex : graph->getBVertices()) {
-		GraphHalfEdge* bHalf = boundaryHalfForBVertex(bVertex);
+		auto* bHalf = findBoundaryHalfEdge(bVertex->getHalfEdges());
 		if (!bHalf) {
-			throw runtime_error("updateBoundaryHalfEdges: boundary vertex has no boundary half-edge");
+			throw runtime_error("updateBoundaryHalfEdges: boundary vertex has no half-edge on the boundary");
 		}
 		bHalfEdges.push_back(bHalf);
 	}

--- a/rule generator/RuleGenerator/RuleExporter.cpp
+++ b/rule generator/RuleGenerator/RuleExporter.cpp
@@ -44,7 +44,7 @@ GraphHalfEdge* firstHalfEdge(GraphVertex* vertex) {
 	return nullptr;
 }
 
-void refreshBVertices(Graph* graph) {
+void updateBoundaryVertices(Graph* graph) {
 	vector<GraphVertex*> bVertices;
 	for (auto* v : graph->getVertices()) {
 		if (v && v->getType() == edgeVertexType()) {
@@ -52,6 +52,30 @@ void refreshBVertices(Graph* graph) {
 		}
 	}
 	graph->setBVertices(bVertices);
+}
+
+GraphHalfEdge* boundaryHalfForBVertex(GraphVertex* bVertex) {
+	if (!bVertex) {
+		return nullptr;
+	}
+	for (auto* half : bVertex->getHalfEdges()) {
+		if (half && !half->getEdge()) {
+			return half;
+		}
+	}
+	return nullptr;
+}
+
+void updateBoundaryHalfEdges(Graph* graph) {
+	vector<GraphHalfEdge*> bHalfEdges;
+	for (auto* bVertex : graph->getBVertices()) {
+		GraphHalfEdge* bHalf = boundaryHalfForBVertex(bVertex);
+		if (!bHalf) {
+			throw runtime_error("updateBoundaryHalfEdges: boundary vertex has no boundary half-edge");
+		}
+		bHalfEdges.push_back(bHalf);
+	}
+	graph->setBHalfEdges(bHalfEdges);
 }
 
 vector<pair<GraphVertex*, GraphVertex*>> findLoopables(Graph* graph) {
@@ -214,7 +238,7 @@ GlueTrack glueVertices(
 
 	netA->removeVertex(vertexA);
 	netA->removeVertex(vertexB);
-	refreshBVertices(netA);
+	updateBoundaryVertices(netA);
 
 	const auto& newBVertices = netA->getBVertices();
 	GlueTrack track;
@@ -300,13 +324,10 @@ Graph* createVertexGraph(VertexType* vType) {
 		const auto& faceData = edgeType->getFaceData();
 		for (size_t faceIndex = 0; faceIndex < faceData.size(); faceIndex++) {
 			const auto& faceDatum = faceData[faceIndex];
-			// Match ms.endpoint.oriented / ms.graphEndpoint.oriented:
-			// forward = onRight XOR (isAtStart ? 0 : 1)
-			bool forward = faceDatum.onRight ^ !isAtStart;
+			int position = faceDatum.onRight ^ isAtStart;
+			bool forward = !faceDatum.onRight;
 			auto* half = (new GraphHalfEdge(forward))->connectGraph(graph);
 			half->connectEdge(graphEdge, (int)faceIndex);
-
-			int position = faceDatum.onRight ^ isAtStart;
 			int faceId = connectionFaceIds[connIndex][faceIndex];
 			auto& faceInfo = faceInfos[faceId];
 			if (!faceInfo.type) {
@@ -364,14 +385,13 @@ Graph* createEdgeGraph(EdgeType* eType) {
 	for (size_t faceIndex = 0; faceIndex < faceData.size(); faceIndex++) {
 		const auto& faceDatum = faceData[faceIndex];
 		bool onRight = faceDatum.onRight;
-		bool start0 = !onRight;
-		// hStart attaches to the start endpoint (bVertex0 when start0).
-		bool forward = onRight ^ !start0;
+		bool forward = !onRight;
 
 		auto* hStart = (new GraphHalfEdge(forward))->connectGraph(graph);
 		auto* hEnd = (new GraphHalfEdge(false))->connectGraph(graph);
 		hStart->connectEdge(graphEdge, (int)faceIndex);
 
+		bool start0 = !onRight;
 		hStart->connectVertex(start0 ? bVertex0 : bVertex1, -1);
 		hEnd->connectVertex(start0 ? bVertex1 : bVertex0, -1);
 
@@ -455,7 +475,9 @@ Graph* buildGraphFromValues(
 	Graph* finalResult = nullptr;
 
 	if (edgeQueue.empty()) {
-		return instances[0].release();
+		Graph* result = instances[0].release();
+		updateBoundaryHalfEdges(result);
+		return result;
 	}
 
 	while (!edgeQueue.empty()) {
@@ -537,6 +559,7 @@ Graph* buildGraphFromValues(
 	if (!finalResult) {
 		throw runtime_error("buildGraphFromValues: no result");
 	}
+	updateBoundaryHalfEdges(finalResult);
 	return releaseInstance(instances, finalResult);
 }
 

--- a/rule generator/RuleGenerator/RuleGenerator.cpp
+++ b/rule generator/RuleGenerator/RuleGenerator.cpp
@@ -147,11 +147,13 @@ void exportGroups(
 ) {
 	for (const auto& group : groups) {
 		// Assumes there are only two graphs in the template set.
-		const int leftIndex = group.graphIndices[0][0];
-		const int rightIndex = group.graphIndices[1][0];
-		auto leftValues = matchers[0].getGraphValues(leftIndex);
-		auto rightValues = matchers[1].getGraphValues(rightIndex);
-		RuleExporter::exportRule(&grammar, leftValues, rightValues, primitives);
+		for (int leftIndex : group.graphIndices[0]) {
+			for (int rightIndex : group.graphIndices[1]) {
+				auto leftValues = matchers[0].getGraphValues(leftIndex);
+				auto rightValues = matchers[1].getGraphValues(rightIndex);
+				RuleExporter::exportRule(&grammar, leftValues, rightValues, primitives);
+			}
+		}
 	}
 }
 

--- a/rule generator/generatedRules.json
+++ b/rule generator/generatedRules.json
@@ -1,0 +1,9515 @@
+{
+  "emptyGraph": {
+    "edgeTypes": [],
+    "faceTypes": [],
+    "interior": {
+      "edges": [],
+      "faces": [],
+      "halfEdges": [],
+      "vertices": []
+    },
+    "morphism": {
+      "faces": [],
+      "halfs": [],
+      "vertices": []
+    },
+    "vertexTypes": []
+  },
+  "groundRules": [],
+  "grounded": false,
+  "rules": [
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            1,
+            0,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 0
+              },
+              {
+                "outerComponent": 5
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": -1,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              2,
+              4
+            ],
+            "vertices": [
+              1,
+              2
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 0
+              },
+              {
+                "outerComponent": 5
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": -1,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              2,
+              4
+            ],
+            "vertices": [
+              0,
+              2
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    2
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    4
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 6,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": -1,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 3,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              1,
+              5
+            ],
+            "vertices": [
+              0,
+              2
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 3
+              },
+              {
+                "outerComponent": 2
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    2
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    4
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 7,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": -1,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 6,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              1,
+              5
+            ],
+            "vertices": [
+              0,
+              3
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "e",
+              "type": 0
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 3
+              },
+              {
+                "outerComponent": 2
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 0
+              },
+              {
+                "outerComponent": 5
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 6,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": -1,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              2,
+              4
+            ],
+            "vertices": [
+              1,
+              3
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "e",
+              "type": 1
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "e",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 0
+              },
+              {
+                "outerComponent": 5
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 7,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": -1,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              2,
+              4
+            ],
+            "vertices": [
+              0,
+              3
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "e",
+              "type": 1
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "e",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    2
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    4
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": -1,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 7,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 2,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              1,
+              5
+            ],
+            "vertices": [
+              1,
+              3
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "e",
+              "type": 1
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 3
+              },
+              {
+                "outerComponent": 2
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "e",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    2
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    3
+                  ],
+                  [
+                    4
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 2
+              },
+              {
+                "outerComponent": 3
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": -1,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 2,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 3,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              1,
+              5
+            ],
+            "vertices": [
+              1,
+              2
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        },
+        {
+          "edgeTypes": [
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 3
+              },
+              {
+                "outerComponent": 2
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 1,
+                "forward": false,
+                "next": -1,
+                "prev": 2,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": -1,
+                "edgeIndex": -1,
+                "face": 0,
+                "forward": false,
+                "next": -1,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": -1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": -1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [
+              0,
+              1
+            ],
+            "vertices": [
+              0,
+              1
+            ]
+          },
+          "vertexTypes": [
+            {
+              "kind": "e",
+              "type": 1
+            },
+            {
+              "kind": "e",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "starterRules": [
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  6
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            1,
+            0,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  7
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 6
+              },
+              {
+                "outerComponent": 7
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  7,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  6,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  1,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  0,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  4
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            0,
+            1
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  6,
+                  0
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  2,
+                  4
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  5,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 3,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 2,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 3,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 2,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  1
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 4,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 5,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 5,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 4,
+                "vertex": 3,
+                "vertexIndex": 0
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  3
+                ]
+              },
+              {
+                "halfEdges": [
+                  7,
+                  5
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 0
+            },
+            {
+              "kind": "v",
+              "type": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ground": false,
+      "n": [
+        {
+          "edgeTypes": [],
+          "faceTypes": [],
+          "interior": {
+            "edges": [],
+            "faces": [],
+            "halfEdges": [],
+            "vertices": []
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": []
+        },
+        {
+          "edgeTypes": [
+            0,
+            1,
+            1,
+            0
+          ],
+          "faceTypes": [
+            0,
+            0
+          ],
+          "interior": {
+            "edges": [
+              {
+                "halfEdges": [
+                  [
+                    0
+                  ],
+                  [
+                    1
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    6
+                  ],
+                  [
+                    7
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    2
+                  ],
+                  [
+                    3
+                  ]
+                ]
+              },
+              {
+                "halfEdges": [
+                  [
+                    4
+                  ],
+                  [
+                    5
+                  ]
+                ]
+              }
+            ],
+            "faces": [
+              {
+                "outerComponent": 7
+              },
+              {
+                "outerComponent": 6
+              }
+            ],
+            "halfEdges": [
+              {
+                "edge": 0,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 2,
+                "prev": 7,
+                "vertex": 0,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 0,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 6,
+                "prev": 3,
+                "vertex": 1,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 0,
+                "face": 0,
+                "forward": false,
+                "next": 5,
+                "prev": 0,
+                "vertex": 1,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 2,
+                "edgeIndex": 1,
+                "face": 1,
+                "forward": true,
+                "next": 1,
+                "prev": 4,
+                "vertex": 2,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 3,
+                "prev": 6,
+                "vertex": 3,
+                "vertexIndex": 0
+              },
+              {
+                "edge": 3,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 7,
+                "prev": 2,
+                "vertex": 2,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 0,
+                "face": 1,
+                "forward": false,
+                "next": 4,
+                "prev": 1,
+                "vertex": 0,
+                "vertexIndex": 1
+              },
+              {
+                "edge": 1,
+                "edgeIndex": 1,
+                "face": 0,
+                "forward": true,
+                "next": 0,
+                "prev": 5,
+                "vertex": 3,
+                "vertexIndex": 1
+              }
+            ],
+            "vertices": [
+              {
+                "halfEdges": [
+                  0,
+                  6
+                ]
+              },
+              {
+                "halfEdges": [
+                  1,
+                  2
+                ]
+              },
+              {
+                "halfEdges": [
+                  3,
+                  5
+                ]
+              },
+              {
+                "halfEdges": [
+                  4,
+                  7
+                ]
+              }
+            ]
+          },
+          "morphism": {
+            "faces": [],
+            "halfs": [],
+            "vertices": []
+          },
+          "vertexTypes": [
+            {
+              "kind": "v",
+              "type": 3
+            },
+            {
+              "kind": "v",
+              "type": 2
+            },
+            {
+              "kind": "v",
+              "type": 1
+            },
+            {
+              "kind": "v",
+              "type": 0
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "types": {
+    "dims": 2,
+    "edgeTypes": [
+      {
+        "dir": {
+          "x": -1.6081226496766364e-16,
+          "y": 1.0,
+          "z": 0.0
+        },
+        "edgeSettings": null,
+        "faceData": [
+          {
+            "onRight": true,
+            "type": 0
+          },
+          {
+            "onRight": false,
+            "type": 0
+          }
+        ],
+        "isRigid": false,
+        "spliced": false
+      },
+      {
+        "dir": {
+          "x": 1.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "edgeSettings": null,
+        "faceData": [
+          {
+            "onRight": true,
+            "type": 0
+          },
+          {
+            "onRight": false,
+            "type": 0
+          }
+        ],
+        "isRigid": false,
+        "spliced": false
+      }
+    ],
+    "faceTypes": [
+      {
+        "color": {
+          "x": 1.0,
+          "y": 1.0,
+          "z": 1.0
+        },
+        "material": "",
+        "normal": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 1.0
+        }
+      }
+    ],
+    "vertexTypes": [
+      {
+        "halfEdgeTypes": [
+          {
+            "dir": {
+              "x": 1.6081226496766364e-16,
+              "y": -1.0,
+              "z": 0.0
+            },
+            "edge": 0,
+            "isAtStart": false
+          },
+          {
+            "dir": {
+              "x": 1.0,
+              "y": 0.0,
+              "z": 0.0
+            },
+            "edge": 1,
+            "isAtStart": true
+          }
+        ],
+        "spliced": false
+      },
+      {
+        "halfEdgeTypes": [
+          {
+            "dir": {
+              "x": 1.0,
+              "y": 0.0,
+              "z": 0.0
+            },
+            "edge": 1,
+            "isAtStart": true
+          },
+          {
+            "dir": {
+              "x": -1.6081226496766364e-16,
+              "y": 1.0,
+              "z": 0.0
+            },
+            "edge": 0,
+            "isAtStart": true
+          }
+        ],
+        "spliced": false
+      },
+      {
+        "halfEdgeTypes": [
+          {
+            "dir": {
+              "x": -1.6081226496766364e-16,
+              "y": 1.0,
+              "z": 0.0
+            },
+            "edge": 0,
+            "isAtStart": true
+          },
+          {
+            "dir": {
+              "x": -1.0,
+              "y": 0.0,
+              "z": 0.0
+            },
+            "edge": 1,
+            "isAtStart": false
+          }
+        ],
+        "spliced": false
+      },
+      {
+        "halfEdgeTypes": [
+          {
+            "dir": {
+              "x": 1.6081226496766364e-16,
+              "y": -1.0,
+              "z": 0.0
+            },
+            "edge": 0,
+            "isAtStart": false
+          },
+          {
+            "dir": {
+              "x": -1.0,
+              "y": 0.0,
+              "z": 0.0
+            },
+            "edge": 1,
+            "isAtStart": false
+          }
+        ],
+        "spliced": false
+      }
+    ]
+  },
+  "version": 2
+}


### PR DESCRIPTION
The boundary half-edges were not being set and the forward value was incorrect. It was false for every half-edge. With this change ruleGenerator works on the two test cases I've tried it on square filled and square hollow.