### PR TITLE
Generate spliced rules

### DIFF
--- a/rule generator/RuleGenerator/CreateSplicedTypes.cpp
+++ b/rule generator/RuleGenerator/CreateSplicedTypes.cpp
@@ -15,48 +15,39 @@ namespace {
 
 constexpr double kDirEps = 1e-10;
 
-Vec3 intoFaceDir(const Vec3& edgeDir, FaceType* face, bool onRight) {
+Vec3 splicedDir(const Vec3& edgeDir, FaceType* face, bool onRight) {
 	const Vec3& n = face->getNormal();
-	Vec3 into = onRight ? edgeDir.cross(n) : n.cross(edgeDir);
-	if (into.length2() < kDirEps) {
-		return Vec3();
-	}
-	into.normalize();
-	return into;
+	Vec3 dir = onRight ? edgeDir.cross(n) : n.cross(edgeDir);
+	dir.normalize();
+	return dir;
 }
 
 VertexType* createSplicedVertexType(
 	EdgeType* edgeType,
-	EdgeType* splicedEdge,
+	EdgeType* splicedType,
 	bool faceOnRight
 ) {
 	auto* vType = new VertexType();
 	vType->setSpliced(true);
 
-	// CCW around the vertex. The two T half-edges point opposite ways.
-	// The spliced half-edge sits between them on the side of this face:
-	//   right face: T-end, spliced, T-start
-	//   left face:  T-end, T-start, spliced
+	// Half-edges are ordered counterclockwise around the vertex.
+	// Two opposite pointing half-edges are based on the edgeType.
 	if (faceOnRight) {
 		vType->addHalfEdge(edgeType, false);
-		vType->addHalfEdge(splicedEdge, true);
+		vType->addHalfEdge(splicedType, true);
 		vType->addHalfEdge(edgeType, true);
 	} else {
 		vType->addHalfEdge(edgeType, false);
 		vType->addHalfEdge(edgeType, true);
-		vType->addHalfEdge(splicedEdge, false);
+		vType->addHalfEdge(splicedType, false);
 	}
-
 	return vType;
 }
 
 }
 
 void filterSplicedTypes(Primitives* primitives) {
-	if (!primitives) {
-		return;
-	}
-
+	// Remove spliced vertex types.
 	vector<VertexType*> vertexTypes;
 	vertexTypes.reserve(primitives->vertexTypes.size());
 	for (VertexType* vType : primitives->vertexTypes) {
@@ -66,6 +57,7 @@ void filterSplicedTypes(Primitives* primitives) {
 	}
 	primitives->vertexTypes = std::move(vertexTypes);
 
+	// Remove spliced edge types.
 	vector<EdgeType*> edgeTypes;
 	edgeTypes.reserve(primitives->edgeTypes.size());
 	for (EdgeType* eType : primitives->edgeTypes) {
@@ -77,10 +69,6 @@ void filterSplicedTypes(Primitives* primitives) {
 }
 
 void createSplicedTypes(Primitives* primitives) {
-	if (!primitives) {
-		return;
-	}
-
 	const int numNormalEdges = (int)primitives->edgeTypes.size();
 	for (int i = 0; i < numNormalEdges; i++) {
 		EdgeType* eType = primitives->edgeTypes[i];
@@ -88,33 +76,32 @@ void createSplicedTypes(Primitives* primitives) {
 		if (eType->getFaceData().size() < 2) {
 			continue;
 		}
-		map<FaceType*, EdgeType*> splicedEdgeByFace;
+
+		// Cache of the spliced edge type for each face.
+		map<FaceType*, EdgeType*> splicedTypeByFace;
 		for (const FaceData& faceDatum : eType->getFaceData()) {
 			FaceType* face = faceDatum.type;
+			bool onRight = faceDatum.onRight;
 			if (!face) {
 				continue;
 			}
-			EdgeType* splicedEdge = nullptr;
-			auto it = splicedEdgeByFace.find(face);
-			if (it == splicedEdgeByFace.end()) {
-				vector<FaceData> faceData = {
-					{face, true},
-					{face, false}
-				};
-				splicedEdge = new EdgeType(
-					faceData,
-					intoFaceDir(eType->getDir(), face, faceDatum.onRight),
-					false
-				);
-				splicedEdge->setSpliced(true);
-				splicedEdgeByFace[face] = splicedEdge;
-				primitives->edgeTypes.push_back(splicedEdge);
+
+			// Create spliced edge type if it doesn't exist.
+			EdgeType* splicedType = nullptr;
+			auto it = splicedTypeByFace.find(face);
+			if (it == splicedTypeByFace.end()) {
+				vector<FaceData> faceData = {{face, true}, {face, false}};
+				auto dir = splicedDir(eType->getDir(), face, onRight);
+				splicedType = new EdgeType(faceData, dir, false);
+				splicedType->setSpliced(true);
+				splicedTypeByFace[face] = splicedType;
+				primitives->edgeTypes.push_back(splicedType);
 			} else {
-				splicedEdge = it->second;
+				splicedType = it->second;
 			}
-			primitives->vertexTypes.push_back(
-				createSplicedVertexType(eType, splicedEdge, faceDatum.onRight)
-			);
+
+			auto splicedVertexType = createSplicedVertexType(eType, splicedType, onRight);
+			primitives->vertexTypes.push_back(splicedVertexType);
 		}
 	}
 }

--- a/rule generator/RuleGenerator/CreateSplicedTypes.cpp
+++ b/rule generator/RuleGenerator/CreateSplicedTypes.cpp
@@ -1,0 +1,139 @@
+#include "pch.h"
+#include "CreateSplicedTypes.h"
+
+#include "../../cpp_version/primitives/primitives.h"
+#include "../../cpp_version/primitives/vertex_type.h"
+#include "../../cpp_version/primitives/edge_type.h"
+#include "../../cpp_version/primitives/face_type.h"
+#include "../../cpp_version/geometry/vec3.h"
+
+#include <cmath>
+#include <map>
+
+using namespace std;
+
+namespace {
+
+constexpr double kDirEps = 1e-10;
+
+Vec3 facePlaneAxis(FaceType* face) {
+	const Vec3& n = face->getNormal();
+	Vec3 q = Vec3::X_AXIS;
+	if (fabs(n.dot(q)) > 0.9) {
+		q = Vec3::Y_AXIS;
+	}
+	Vec3 axis = n.cross(q);
+	axis.normalize();
+	return axis;
+}
+
+Vec3 intoFaceDir(const Vec3& edgeDir, FaceType* face, bool onRight) {
+	const Vec3& n = face->getNormal();
+	Vec3 into = onRight ? edgeDir.cross(n) : n.cross(edgeDir);
+	if (into.length2() < kDirEps) {
+		return Vec3();
+	}
+	into.normalize();
+	return into;
+}
+
+VertexType* createSplicedVertexType(
+	EdgeType* edgeType,
+	EdgeType* splicedEdge,
+	FaceType* face,
+	bool faceOnRight
+) {
+	auto* vType = new VertexType();
+	vType->setSpliced(true);
+
+	// CCW around the vertex. The two T half-edges point opposite ways.
+	// The spliced half-edge sits between them on the side of this face:
+	//   right face: T-end, spliced, T-start
+	//   left face:  T-end, T-start, spliced
+	if (faceOnRight) {
+		vType->addHalfEdge(edgeType, false);
+		vType->addHalfEdge(splicedEdge, true);
+		vType->addHalfEdge(edgeType, true);
+	} else {
+		vType->addHalfEdge(edgeType, false);
+		vType->addHalfEdge(edgeType, true);
+		vType->addHalfEdge(splicedEdge, false);
+	}
+
+	Vec3 into = intoFaceDir(edgeType->getDir(), face, faceOnRight);
+	if (into.length2() >= kDirEps) {
+		vector<HalfEdgeType> halfEdges = vType->getHalfEdgeTypes();
+		const int splicedIndex = faceOnRight ? 1 : 2;
+		halfEdges[splicedIndex].dir = into;
+		vType->setHalfEdgeTypes(std::move(halfEdges));
+	}
+	return vType;
+}
+
+}
+
+void filterSplicedTypes(Primitives* primitives) {
+	if (!primitives) {
+		return;
+	}
+
+	vector<VertexType*> vertexTypes;
+	vertexTypes.reserve(primitives->vertexTypes.size());
+	for (VertexType* vType : primitives->vertexTypes) {
+		if (!vType->getSpliced()) {
+			vertexTypes.push_back(vType);
+		}
+	}
+	primitives->vertexTypes = std::move(vertexTypes);
+
+	vector<EdgeType*> edgeTypes;
+	edgeTypes.reserve(primitives->edgeTypes.size());
+	for (EdgeType* eType : primitives->edgeTypes) {
+		if (!eType->getSpliced()) {
+			edgeTypes.push_back(eType);
+		}
+	}
+	primitives->edgeTypes = std::move(edgeTypes);
+}
+
+void createSplicedTypes(Primitives* primitives) {
+	if (!primitives) {
+		return;
+	}
+
+	const int numNormalEdges = (int)primitives->edgeTypes.size();
+	map<FaceType*, EdgeType*> splicedEdgeByFace;
+	for (int i = 0; i < numNormalEdges; i++) {
+		EdgeType* eType = primitives->edgeTypes[i];
+		for (const FaceData& faceDatum : eType->getFaceData()) {
+			FaceType* face = faceDatum.type;
+			if (!face || splicedEdgeByFace.count(face)) {
+				continue;
+			}
+			vector<FaceData> faceData = {
+				{face, true},
+				{face, false}
+			};
+			auto* splicedEdge = new EdgeType(faceData, facePlaneAxis(face), false);
+			splicedEdge->setSpliced(true);
+			splicedEdgeByFace[face] = splicedEdge;
+			primitives->edgeTypes.push_back(splicedEdge);
+		}
+	}
+
+	for (int i = 0; i < numNormalEdges; i++) {
+		EdgeType* eType = primitives->edgeTypes[i];
+		for (const FaceData& faceDatum : eType->getFaceData()) {
+			FaceType* face = faceDatum.type;
+			if (!face) {
+				continue;
+			}
+			auto it = splicedEdgeByFace.find(face);
+			if (it == splicedEdgeByFace.end()) {
+				continue;
+			}
+			VertexType* vType = createSplicedVertexType(eType, it->second, face, faceDatum.onRight);
+			primitives->vertexTypes.push_back(vType);
+		}
+	}
+}

--- a/rule generator/RuleGenerator/CreateSplicedTypes.cpp
+++ b/rule generator/RuleGenerator/CreateSplicedTypes.cpp
@@ -7,7 +7,6 @@
 #include "../../cpp_version/primitives/face_type.h"
 #include "../../cpp_version/geometry/vec3.h"
 
-#include <cmath>
 #include <map>
 
 using namespace std;
@@ -15,17 +14,6 @@ using namespace std;
 namespace {
 
 constexpr double kDirEps = 1e-10;
-
-Vec3 facePlaneAxis(FaceType* face) {
-	const Vec3& n = face->getNormal();
-	Vec3 q = Vec3::X_AXIS;
-	if (fabs(n.dot(q)) > 0.9) {
-		q = Vec3::Y_AXIS;
-	}
-	Vec3 axis = n.cross(q);
-	axis.normalize();
-	return axis;
-}
 
 Vec3 intoFaceDir(const Vec3& edgeDir, FaceType* face, bool onRight) {
 	const Vec3& n = face->getNormal();
@@ -40,7 +28,6 @@ Vec3 intoFaceDir(const Vec3& edgeDir, FaceType* face, bool onRight) {
 VertexType* createSplicedVertexType(
 	EdgeType* edgeType,
 	EdgeType* splicedEdge,
-	FaceType* face,
 	bool faceOnRight
 ) {
 	auto* vType = new VertexType();
@@ -60,13 +47,6 @@ VertexType* createSplicedVertexType(
 		vType->addHalfEdge(splicedEdge, false);
 	}
 
-	Vec3 into = intoFaceDir(edgeType->getDir(), face, faceOnRight);
-	if (into.length2() >= kDirEps) {
-		vector<HalfEdgeType> halfEdges = vType->getHalfEdgeTypes();
-		const int splicedIndex = faceOnRight ? 1 : 2;
-		halfEdges[splicedIndex].dir = into;
-		vType->setHalfEdgeTypes(std::move(halfEdges));
-	}
 	return vType;
 }
 
@@ -102,46 +82,39 @@ void createSplicedTypes(Primitives* primitives) {
 	}
 
 	const int numNormalEdges = (int)primitives->edgeTypes.size();
-	map<FaceType*, EdgeType*> splicedEdgeByFace;
 	for (int i = 0; i < numNormalEdges; i++) {
 		EdgeType* eType = primitives->edgeTypes[i];
 		// Ignore ground plane edges with one half-edge.
 		if (eType->getFaceData().size() < 2) {
 			continue;
 		}
-		for (const FaceData& faceDatum : eType->getFaceData()) {
-			FaceType* face = faceDatum.type;
-			if (!face || splicedEdgeByFace.count(face)) {
-				continue;
-			}
-			vector<FaceData> faceData = {
-				{face, true},
-				{face, false}
-			};
-			auto* splicedEdge = new EdgeType(faceData, facePlaneAxis(face), false);
-			splicedEdge->setSpliced(true);
-			splicedEdgeByFace[face] = splicedEdge;
-			primitives->edgeTypes.push_back(splicedEdge);
-		}
-	}
-
-	for (int i = 0; i < numNormalEdges; i++) {
-		EdgeType* eType = primitives->edgeTypes[i];
-		// Ignore ground plane edges with one half-edge.
-		if (eType->getFaceData().size() < 2) {
-			continue;
-		}
+		map<FaceType*, EdgeType*> splicedEdgeByFace;
 		for (const FaceData& faceDatum : eType->getFaceData()) {
 			FaceType* face = faceDatum.type;
 			if (!face) {
 				continue;
 			}
+			EdgeType* splicedEdge = nullptr;
 			auto it = splicedEdgeByFace.find(face);
 			if (it == splicedEdgeByFace.end()) {
-				continue;
+				vector<FaceData> faceData = {
+					{face, true},
+					{face, false}
+				};
+				splicedEdge = new EdgeType(
+					faceData,
+					intoFaceDir(eType->getDir(), face, faceDatum.onRight),
+					false
+				);
+				splicedEdge->setSpliced(true);
+				splicedEdgeByFace[face] = splicedEdge;
+				primitives->edgeTypes.push_back(splicedEdge);
+			} else {
+				splicedEdge = it->second;
 			}
-			VertexType* vType = createSplicedVertexType(eType, it->second, face, faceDatum.onRight);
-			primitives->vertexTypes.push_back(vType);
+			primitives->vertexTypes.push_back(
+				createSplicedVertexType(eType, splicedEdge, faceDatum.onRight)
+			);
 		}
 	}
 }

--- a/rule generator/RuleGenerator/CreateSplicedTypes.cpp
+++ b/rule generator/RuleGenerator/CreateSplicedTypes.cpp
@@ -105,6 +105,10 @@ void createSplicedTypes(Primitives* primitives) {
 	map<FaceType*, EdgeType*> splicedEdgeByFace;
 	for (int i = 0; i < numNormalEdges; i++) {
 		EdgeType* eType = primitives->edgeTypes[i];
+		// Ignore ground plane edges with one half-edge.
+		if (eType->getFaceData().size() < 2) {
+			continue;
+		}
 		for (const FaceData& faceDatum : eType->getFaceData()) {
 			FaceType* face = faceDatum.type;
 			if (!face || splicedEdgeByFace.count(face)) {
@@ -123,6 +127,10 @@ void createSplicedTypes(Primitives* primitives) {
 
 	for (int i = 0; i < numNormalEdges; i++) {
 		EdgeType* eType = primitives->edgeTypes[i];
+		// Ignore ground plane edges with one half-edge.
+		if (eType->getFaceData().size() < 2) {
+			continue;
+		}
 		for (const FaceData& faceDatum : eType->getFaceData()) {
 			FaceType* face = faceDatum.type;
 			if (!face) {

--- a/rule generator/RuleGenerator/CreateSplicedTypes.h
+++ b/rule generator/RuleGenerator/CreateSplicedTypes.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class Primitives;
+
+// Remove any spliced vertex types and spliced edge types.
+void filterSplicedTypes(Primitives* primitives);
+
+// Create spliced vertex types and spliced edge types and add them
+// to the primitives.
+void createSplicedTypes(Primitives* primitives);

--- a/rule generator/RuleGenerator/RuleExporter.cpp
+++ b/rule generator/RuleGenerator/RuleExporter.cpp
@@ -444,7 +444,9 @@ PrimitiveGraphs createPrimitiveGraphs(Primitives* primitives) {
 	PrimitiveGraphs result;
 	result.vertexGraphs.reserve(primitives->vertexTypes.size());
 	for (auto* vType : primitives->vertexTypes) {
-		result.vertexGraphs.push_back(unique_ptr<Graph>(createVertexGraph(vType)));
+		// if (!vType->getSpliced()) {
+			result.vertexGraphs.push_back(unique_ptr<Graph>(createVertexGraph(vType)));
+		// }
 	}
 
 	result.edgeGraphs.reserve(primitives->edgeTypes.size());

--- a/rule generator/RuleGenerator/RuleExporter.cpp
+++ b/rule generator/RuleGenerator/RuleExporter.cpp
@@ -444,9 +444,7 @@ PrimitiveGraphs createPrimitiveGraphs(Primitives* primitives) {
 	PrimitiveGraphs result;
 	result.vertexGraphs.reserve(primitives->vertexTypes.size());
 	for (auto* vType : primitives->vertexTypes) {
-		// if (!vType->getSpliced()) {
-			result.vertexGraphs.push_back(unique_ptr<Graph>(createVertexGraph(vType)));
-		// }
+		result.vertexGraphs.push_back(unique_ptr<Graph>(createVertexGraph(vType)));
 	}
 
 	result.edgeGraphs.reserve(primitives->edgeTypes.size());
@@ -642,17 +640,20 @@ Graph* createFaceGraph(FaceType* face) {
 	auto* graphFace = (new GraphFace())->connectGraph(graph);
 	graphFace->setType(face);
 	graphFace->setOuterComponent(nullptr);
-	graph->setBFaces({ graphFace });
 	graph->setBHalfEdges({ nullptr });
 	return graph;
 }
 
 // Add a boundary face to both graphs, if the filled graph has an outer loop.
-void maybeAddBFace(Graph*& graph, Graph* filledGraph) {
+void maybeAddBFace(Graph*& graph, Graph* filledGraph, bool addBFaces) {
 	GraphFace* outerFace = findOuterLoopFace(filledGraph);
-	if (outerFace) {
-		delete graph;
-		graph = createFaceGraph(outerFace->getType());
+	if (!outerFace) {
+		return;
+	}
+	delete graph;
+	graph = createFaceGraph(outerFace->getType());
+	if (addBFaces) {
+		graph->setBFaces({ graph->getFaces()[0] });
 		filledGraph->setBFaces({ outerFace });
 	}
 }
@@ -669,10 +670,14 @@ void exportRule(
 		const int numRightEdges = (int)rightGraph->getEdges().size();
 		const bool leftEmpty = numLeftVertices == 0 && numLeftEdges == 0;
 		const bool rightEmpty = numRightVertices == 0 && numRightEdges == 0;
+
+		// TODO: The last parameter should probably be removed. It there because
+		// we do not have any faces for 2D graphs to be attached to. In the future,
+		// we should create a default ground plane for them.
 		if (leftEmpty) {
-			maybeAddBFace(leftGraph, rightGraph);
+			maybeAddBFace(leftGraph, rightGraph, grammar->isGrounded());
 		} else if (rightEmpty) {
-			maybeAddBFace(rightGraph, leftGraph);
+			maybeAddBFace(rightGraph, leftGraph, grammar->isGrounded());
 		}
         // If a graph is empty, it should go first.
 		vector<Graph*> graphs = rightEmpty

--- a/rule generator/RuleGenerator/RuleExporter.cpp
+++ b/rule generator/RuleGenerator/RuleExporter.cpp
@@ -33,6 +33,7 @@ struct HalfEdgeFaceSlot {
 	GraphHalfEdge* halfEdge = nullptr;
 };
 
+// Sort half-edge face slots by angle.
 static bool compareHalfEdgeFaceSlots(const HalfEdgeFaceSlot& a, const HalfEdgeFaceSlot& b) {
 	if (a.angle != b.angle) {
 		return a.angle < b.angle;
@@ -41,6 +42,29 @@ static bool compareHalfEdgeFaceSlots(const HalfEdgeFaceSlot& a, const HalfEdgeFa
 		return a.intoVertex < b.intoVertex;
 	}
 	return false;
+}
+
+// We cannot decide the order of two half-edges based on angle if they have the same angle.
+// Instead, we look at the previous slot. intoVertex should alternate between true and false.
+// Choose the order that accomplishes this.
+static void orderSameAnglePairs(vector<HalfEdgeFaceSlot>& slots) {
+	const size_t n = slots.size();
+	if (n < 2) {
+		return;
+	}
+	for (size_t i = 0; i + 1 < n; ) {
+		if (slots[i].angle == slots[i + 1].angle) {
+			const size_t prev = (i + n - 1) % n;
+			const bool prevIntoVertex = slots[prev].intoVertex;
+			// If the current slot matches the previous slot, swap the current and next slots.
+			if (slots[i].intoVertex == prevIntoVertex) {
+				swap(slots[i], slots[i + 1]);
+			}
+			i += 2;
+		} else {
+			i++;
+		}
+	}
 }
 
 // Find the outward facing partner half-edge for a slot facing into the vertex.
@@ -362,6 +386,7 @@ Graph* createVertexGraph(VertexType* vType) {
 	// Sort half-edges by their face angle.
 	for (auto& entry : halfEdgesByFaceType) {
 		stable_sort(entry.second.begin(), entry.second.end(), compareHalfEdgeFaceSlots);
+		orderSameAnglePairs(entry.second);
 	}
 
 	// For each inward facing half-edge, find it's outward facing partner and create a face.

--- a/rule generator/RuleGenerator/RuleExporter.cpp
+++ b/rule generator/RuleGenerator/RuleExporter.cpp
@@ -672,14 +672,13 @@ Graph* createFaceGraph(FaceType* face) {
 // Add a boundary face to both graphs, if the filled graph has an outer loop.
 void maybeAddBFace(Graph*& graph, Graph* filledGraph, bool addBFaces) {
 	GraphFace* outerFace = findOuterLoopFace(filledGraph);
-	if (!outerFace) {
-		return;
-	}
-	delete graph;
-	graph = createFaceGraph(outerFace->getType());
-	if (addBFaces) {
-		graph->setBFaces({ graph->getFaces()[0] });
-		filledGraph->setBFaces({ outerFace });
+	if (outerFace) {
+		delete graph;
+		graph = createFaceGraph(outerFace->getType());
+		if (addBFaces) {
+			graph->setBFaces({graph->getFaces()[0]});
+			filledGraph->setBFaces({ outerFace });
+		}
 	}
 }
 

--- a/rule generator/RuleGenerator/RuleGenerator.cpp
+++ b/rule generator/RuleGenerator/RuleGenerator.cpp
@@ -4,6 +4,7 @@
 #include "TemplateMatcher.h"
 #include "RuleExporter.h"
 #include "FixHalfEdgeOrder.h"
+#include "CreateSplicedTypes.h"
 #include "CreateGroundRule.h"
 #include "../../cpp_version/json versioning/read_json_file.h"
 #include "../../cpp_version/primitives/primitives.h"
@@ -166,24 +167,19 @@ int GenerateRules(
 		Json parsed = readJsonFile(primitivesPath);
 		Primitives* primitives = Primitives::import(parsed["types"]);
 
-		vector<VertexType*> vertexTypes;
-		vertexTypes.reserve(primitives->vertexTypes.size());
-		for (VertexType* vType : primitives->vertexTypes) {
-			if (vType->getSpliced()) {
-				continue;
-			}
-			vertexTypes.push_back(vType);
-		}
-		primitives->vertexTypes = std::move(vertexTypes);
-
-		fixHalfEdgeOrder(primitives->vertexTypes);
+		filterSplicedTypes(primitives);
+		vector<VertexType*> vertexTypes = primitives->vertexTypes;
+		createSplicedTypes(primitives);
+		fixHalfEdgeOrder(vertexTypes);
 		GraphGrammar grammar(primitives);
 
 		vector<EdgeType*> eTypes;
 		for (size_t i = 0; i < primitives->edgeTypes.size(); i++) {
 			EdgeType* eType = primitives->edgeTypes[i];
 			eType->setRuleGeneratorId("edge" + to_string(i));
-			eTypes.push_back(eType);
+			if (!eType->getSpliced()) {
+				eTypes.push_back(eType);
+			}
 		}
 
 		for (size_t i = 0; i < primitives->vertexTypes.size(); i++) {
@@ -216,7 +212,11 @@ int GenerateRules(
 				continue;
 			}
 			for (int j = 0; j < numGraphs; j++) {
-				matchers.push_back(TemplateMatcher(templateGraphSets[i].graphs[j], primitives->vertexTypes, eTypes));
+				matchers.push_back(TemplateMatcher(
+					templateGraphSets[i].graphs[j],
+					primitives->vertexTypes,
+					eTypes
+				));
 			}
 			vector<vector<vector<int>>> allBoundaryValues;
 			vector<string> boundaryIds = collectBoundaryIds(templateGraphSets[i].graphs[0]);

--- a/rule generator/RuleGenerator/RuleGenerator.cpp
+++ b/rule generator/RuleGenerator/RuleGenerator.cpp
@@ -212,16 +212,14 @@ int GenerateRules(
 				continue;
 			}
 			for (int j = 0; j < numGraphs; j++) {
-				matchers.push_back(TemplateMatcher(
-					templateGraphSets[i].graphs[j],
-					primitives->vertexTypes,
-					eTypes
-				));
+				const auto& templateGraph = templateGraphSets[i].graphs[j];
+				matchers.push_back(TemplateMatcher(templateGraph, primitives->vertexTypes, eTypes));
 			}
 			vector<vector<vector<int>>> allBoundaryValues;
 			vector<string> boundaryIds = collectBoundaryIds(templateGraphSets[i].graphs[0]);
 			for (int j = 0; j < numGraphs; j++) {
 				matchers[j].match();
+				totalMatches += matchers[j].vertexValues.size();
 				auto boundaryValues = findBoundaryValues(matchers[j], boundaryIds);
 				allBoundaryValues.push_back(boundaryValues);
 				cout << "    graph " << j << " allBoundaryValues:\n";

--- a/rule generator/RuleGenerator/RuleGenerator.vcxproj
+++ b/rule generator/RuleGenerator/RuleGenerator.vcxproj
@@ -185,6 +185,7 @@
     <ClInclude Include="RuleGenerator.h" />
     <ClInclude Include="State.h" />
     <ClInclude Include="CreateGroundRule.h" />
+    <ClInclude Include="CreateSplicedTypes.h" />
     <ClInclude Include="FixHalfEdgeOrder.h" />
     <ClInclude Include="TemplateGraph.h" />
     <ClInclude Include="TemplateMatcher.h" />
@@ -259,6 +260,7 @@
     <ClCompile Include="RuleGenerator.cpp" />
     <ClCompile Include="State.cpp" />
     <ClCompile Include="CreateGroundRule.cpp" />
+    <ClCompile Include="CreateSplicedTypes.cpp" />
     <ClCompile Include="FixHalfEdgeOrder.cpp" />
     <ClCompile Include="TemplateMatcher.cpp" />
   </ItemGroup>

--- a/rule generator/RuleGenerator/RuleGenerator.vcxproj.filters
+++ b/rule generator/RuleGenerator/RuleGenerator.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClInclude Include="CreateGroundRule.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CreateSplicedTypes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="FixHalfEdgeOrder.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -132,6 +135,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="CreateGroundRule.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CreateSplicedTypes.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FixHalfEdgeOrder.cpp">

--- a/rule generator/RuleGenerator/TemplateMatcher.cpp
+++ b/rule generator/RuleGenerator/TemplateMatcher.cpp
@@ -8,32 +8,21 @@ using namespace std;
 
 namespace {
 
+// Find the index of the spliced connection in the vertex if any.
 int splicedConnectionIndex(const TemplateGraph& graph, const TemplateVertex& vertex) {
 	for (int i = 0; i < (int)vertex.connections.size(); i++) {
-		const int edgeIndex = vertex.connections[i];
-		if (edgeIndex >= 0 && edgeIndex < (int)graph.edges.size() && graph.edges[edgeIndex].spliced) {
+		const int eIndex = vertex.connections[i];
+		if (graph.edges[eIndex].spliced) {
 			return i;
 		}
 	}
 	return -1;
 }
 
-bool halfEdgeIsSpliced(const VertexState& state, int halfEdgeIndex) {
+bool halfEdgeIsSpliced(const VertexState& state, int hIndex) {
 	const auto& halfEdges = state.getType()->getHalfEdgeTypes();
-	if (halfEdgeIndex < 0 || halfEdgeIndex >= (int)halfEdges.size()) {
-		return false;
-	}
-	return halfEdges[halfEdgeIndex].edge && halfEdges[halfEdgeIndex].edge->getSpliced();
-}
-
-void addVertexStates(vector<VertexState>& states, const vector<VertexType*>& vTypes) {
-	for (VertexType* vType : vTypes) {
-		const int typeValue = vType->getRuleGeneratorId();
-		const int n = (int)vType->getHalfEdgeTypes().size();
-		for (int j = 0; j < n; j++) {
-			states.push_back(VertexState(vType, typeValue, j));
-		}
-	}
+	const auto edge = halfEdges[hIndex].edge;
+	return edge && edge->getSpliced();
 }
 
 }
@@ -44,17 +33,8 @@ TemplateMatcher::TemplateMatcher(
 	vector<EdgeType*> eTypes
 ) : templateGraph(templateGraph_) {
 	counter = 0;
-	vector<VertexType*> normalTypes;
-	vector<VertexType*> splicedTypes;
-	for (VertexType* vType : vTypes) {
-		if (vType->getSpliced()) {
-			splicedTypes.push_back(vType);
-		} else {
-			normalTypes.push_back(vType);
-		}
-	}
-	addVertexStates(vertexStates, normalTypes);
-	addVertexStates(splicedVertexStates, splicedTypes);
+	addVertexStates(vTypes);
+
 	for (int i = 0; i < (int)eTypes.size(); i++) {
 		EdgeType* eType = eTypes[i];
 		string id = eType->getRuleGeneratorId();
@@ -72,14 +52,14 @@ TemplateMatcher::TemplateMatcher(
 	}
 
 	// -1 means not rejected.
-	inQueue = new bool[numTemplateVertices];
+	inQueue.assign(numTemplateVertices, false);
 	for (int i = 0; i < numTemplateVertices; i++) {
-		inQueue[i] = false;
 		vector<int> rejectStepOneVertex;
 		const auto& templateVertex = templateGraph.vertices[i];
 		const int numConnections = (int)templateVertex.connections.size();
 		const bool onBoundary = !templateVertex.boundaryId.empty();
-		const int splicedConn = templateVertex.spliced
+		const bool isSpliced = templateVertex.spliced;
+		const int splicedConn = isSpliced
 			? splicedConnectionIndex(templateGraph, templateVertex)
 			: -1;
 		int numStates = numStatesAtVertex(i);
@@ -87,11 +67,13 @@ TemplateMatcher::TemplateMatcher(
 			int rejectAt = -1;
 			if (!onBoundary) {
 				const auto& state = static_cast<const VertexState&>(getState(i, j));
+				// Reject any state that does not have the correct number of edges.
 				if (state.getType()->getHalfEdgeTypes().size() != numConnections) {
 					rejectAt = 0;
-				} else if (templateVertex.spliced) {
-					if (splicedConn < 0 ||
-						!halfEdgeIsSpliced(state, state.GetConnectionIndex(splicedConn))) {
+				} else if (isSpliced) {
+					// The template's spliced connection must land on a spliced half-edge.
+					const int splicedIndex = state.GetConnectionIndex(splicedConn);
+					if (splicedConn == -1 || !halfEdgeIsSpliced(state, splicedIndex)) {
 						rejectAt = 0;
 					}
 				}
@@ -101,6 +83,17 @@ TemplateMatcher::TemplateMatcher(
 		rejectionStep.push_back(rejectStepOneVertex);
 	}
 	vIndex = 0;
+}
+
+void TemplateMatcher::addVertexStates(const vector<VertexType*>& vTypes) {
+	for (VertexType* vType : vTypes) {
+		const int typeValue = vType->getRuleGeneratorId();
+		const int n = (int)vType->getHalfEdgeTypes().size();
+		auto& states = vType->getSpliced() ? splicedVertexStates : vertexStates;
+		for (int i = 0; i < n; i++) {
+			states.push_back(VertexState(vType, typeValue, i));
+		}
+	}
 }
 
 int TemplateMatcher::numStatesAtVertex(int vIndex) {

--- a/rule generator/RuleGenerator/TemplateMatcher.cpp
+++ b/rule generator/RuleGenerator/TemplateMatcher.cpp
@@ -44,7 +44,17 @@ TemplateMatcher::TemplateMatcher(
 	vector<EdgeType*> eTypes
 ) : templateGraph(templateGraph_) {
 	counter = 0;
-	addVertexStates(vertexStates, vTypes);
+	vector<VertexType*> normalTypes;
+	vector<VertexType*> splicedTypes;
+	for (VertexType* vType : vTypes) {
+		if (vType->getSpliced()) {
+			splicedTypes.push_back(vType);
+		} else {
+			normalTypes.push_back(vType);
+		}
+	}
+	addVertexStates(vertexStates, normalTypes);
+	addVertexStates(splicedVertexStates, splicedTypes);
 	for (int i = 0; i < (int)eTypes.size(); i++) {
 		EdgeType* eType = eTypes[i];
 		string id = eType->getRuleGeneratorId();
@@ -52,6 +62,7 @@ TemplateMatcher::TemplateMatcher(
 		edgeStates.push_back(EdgeState(id + "E", i, 1));
 	}
 	numVertexStates = (int)vertexStates.size();
+	numSplicedVertexStates = (int)splicedVertexStates.size();
 	numEdgeStates = (int)edgeStates.size();
 	numTemplateVertices = (int)templateGraph.vertices.size();
 
@@ -76,9 +87,7 @@ TemplateMatcher::TemplateMatcher(
 			int rejectAt = -1;
 			if (!onBoundary) {
 				const auto& state = static_cast<const VertexState&>(getState(i, j));
-				if (state.getType()->getSpliced() != templateVertex.spliced) {
-					rejectAt = 0;
-				} else if (state.getType()->getHalfEdgeTypes().size() != numConnections) {
+				if (state.getType()->getHalfEdgeTypes().size() != numConnections) {
 					rejectAt = 0;
 				} else if (templateVertex.spliced) {
 					if (splicedConn < 0 ||
@@ -95,13 +104,22 @@ TemplateMatcher::TemplateMatcher(
 }
 
 int TemplateMatcher::numStatesAtVertex(int vIndex) {
-	return templateGraph.vertices[vIndex].boundaryId.empty() ? numVertexStates : numEdgeStates;
+	const auto& vertex = templateGraph.vertices[vIndex];
+	if (!vertex.boundaryId.empty()) {
+		return numEdgeStates;
+	}
+	return vertex.spliced ? numSplicedVertexStates : numVertexStates;
 }
 
 const State& TemplateMatcher::getState(int vIndex, int stateIndex) const {
-	return templateGraph.vertices[vIndex].boundaryId.empty()
-		? static_cast<const State&>(vertexStates[stateIndex])
-		: static_cast<const State&>(edgeStates[stateIndex]);
+	const auto& vertex = templateGraph.vertices[vIndex];
+	if (!vertex.boundaryId.empty()) {
+		return edgeStates[stateIndex];
+	}
+	if (vertex.spliced) {
+		return splicedVertexStates[stateIndex];
+	}
+	return vertexStates[stateIndex];
 }
 
 void TemplateMatcher::match() {

--- a/rule generator/RuleGenerator/TemplateMatcher.cpp
+++ b/rule generator/RuleGenerator/TemplateMatcher.cpp
@@ -1,9 +1,42 @@
 #include "pch.h"
 #include "TemplateMatcher.h"
+#include "../../cpp_version/primitives/edge_type.h"
 #include <set>
 #include <iostream>
 
 using namespace std;
+
+namespace {
+
+int splicedConnectionIndex(const TemplateGraph& graph, const TemplateVertex& vertex) {
+	for (int i = 0; i < (int)vertex.connections.size(); i++) {
+		const int edgeIndex = vertex.connections[i];
+		if (edgeIndex >= 0 && edgeIndex < (int)graph.edges.size() && graph.edges[edgeIndex].spliced) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+bool halfEdgeIsSpliced(const VertexState& state, int halfEdgeIndex) {
+	const auto& halfEdges = state.getType()->getHalfEdgeTypes();
+	if (halfEdgeIndex < 0 || halfEdgeIndex >= (int)halfEdges.size()) {
+		return false;
+	}
+	return halfEdges[halfEdgeIndex].edge && halfEdges[halfEdgeIndex].edge->getSpliced();
+}
+
+void addVertexStates(vector<VertexState>& states, const vector<VertexType*>& vTypes) {
+	for (VertexType* vType : vTypes) {
+		const int typeValue = vType->getRuleGeneratorId();
+		const int n = (int)vType->getHalfEdgeTypes().size();
+		for (int j = 0; j < n; j++) {
+			states.push_back(VertexState(vType, typeValue, j));
+		}
+	}
+}
+
+}
 
 TemplateMatcher::TemplateMatcher(
 	TemplateGraph templateGraph_,
@@ -11,13 +44,8 @@ TemplateMatcher::TemplateMatcher(
 	vector<EdgeType*> eTypes
 ) : templateGraph(templateGraph_) {
 	counter = 0;
-	for (int i = 0; i < vTypes.size(); i++) {
-		VertexType* vType = vTypes[i];
-		for (int j = 0; j < vType->getHalfEdgeTypes().size(); j++) {
-			vertexStates.push_back(VertexState(vType, i, j));
-		}
-	}
-	for (int i = 0; i < eTypes.size(); i++) {
+	addVertexStates(vertexStates, vTypes);
+	for (int i = 0; i < (int)eTypes.size(); i++) {
 		EdgeType* eType = eTypes[i];
 		string id = eType->getRuleGeneratorId();
 		edgeStates.push_back(EdgeState(id + "S", i, 0));
@@ -36,16 +64,28 @@ TemplateMatcher::TemplateMatcher(
 	inQueue = new bool[numTemplateVertices];
 	for (int i = 0; i < numTemplateVertices; i++) {
 		inQueue[i] = false;
-		vector <int> rejectStepOneVertex;
+		vector<int> rejectStepOneVertex;
 		const auto& templateVertex = templateGraph.vertices[i];
 		const int numConnections = (int)templateVertex.connections.size();
 		const bool onBoundary = !templateVertex.boundaryId.empty();
+		const int splicedConn = templateVertex.spliced
+			? splicedConnectionIndex(templateGraph, templateVertex)
+			: -1;
 		int numStates = numStatesAtVertex(i);
 		for (int j = 0; j < numStates; j++) {
 			int rejectAt = -1;
-			// Immediately reject any state that does not have the correct number of edges.
-			if (!onBoundary && vertexStates[j].getType()->getHalfEdgeTypes().size() != numConnections) {
-				rejectAt = 0;
+			if (!onBoundary) {
+				const auto& state = static_cast<const VertexState&>(getState(i, j));
+				if (state.getType()->getSpliced() != templateVertex.spliced) {
+					rejectAt = 0;
+				} else if (state.getType()->getHalfEdgeTypes().size() != numConnections) {
+					rejectAt = 0;
+				} else if (templateVertex.spliced) {
+					if (splicedConn < 0 ||
+						!halfEdgeIsSpliced(state, state.GetConnectionIndex(splicedConn))) {
+						rejectAt = 0;
+					}
+				}
 			}
 			rejectStepOneVertex.push_back(rejectAt);
 		}

--- a/rule generator/RuleGenerator/TemplateMatcher.h
+++ b/rule generator/RuleGenerator/TemplateMatcher.h
@@ -28,8 +28,10 @@ public:
 
 class TemplateMatcher {
 public:
-	// The possible states at each vertex.
+	// The possible states at each non-spliced vertex.
 	vector<VertexState> vertexStates;
+	// The possible states at each spliced vertex.
+	vector<VertexState> splicedVertexStates;
 	// The possible states at each edge.
 	vector<EdgeState> edgeStates;
 	// The list of decisions.
@@ -45,6 +47,7 @@ public:
 	vector<vector<int>> eConnections;
 	int numTemplateVertices;
 	int numVertexStates;
+	int numSplicedVertexStates;
 	int numEdgeStates;
 	// Our current position within the vertices.
 	int vIndex;

--- a/rule generator/RuleGenerator/TemplateMatcher.h
+++ b/rule generator/RuleGenerator/TemplateMatcher.h
@@ -40,7 +40,7 @@ public:
 	// If it is at -1, the state has not been rejected.
 	vector<vector<int>> rejectionStep;
 	// If each vertex is in the updateQueue.
-	bool* inQueue;
+	vector<bool> inQueue;
 	vector<int> updateQueue;
 	TemplateGraph templateGraph;
 	// Edge connections: which vertices are connected to each edge.
@@ -62,6 +62,7 @@ public:
 	GraphValues getGraphValues(int graphIndex) const;
 
 private:
+	void addVertexStates(const vector<VertexType*>& vTypes);
 	void applyDecision();
 	bool propagate();
 	vector<int> findChoices();

--- a/rule generator/RuleGenerator/main.cpp
+++ b/rule generator/RuleGenerator/main.cpp
@@ -28,8 +28,8 @@ using namespace std;
 
 namespace {
 
-const char* kDefaultLibrary = "../graph templates/L template.json";
-constexpr const char* kDefaultPrimitives = "../primitives/L-grounded.json";
+const char* kDefaultLibrary = "../graph templates/H.json";
+constexpr const char* kDefaultPrimitives = "../primitives/H.json";
 
 // constexpr const char* kDefaultLibrary = "../graph templates/graph_template_diagonal.json";
 // constexpr const char* kDefaultPrimitives = "../primitives/diagonal box.json";


### PR DESCRIPTION
Use spliced vertex types when generating rules. Only a spliced vertex type can be placed on spliced vertex in the template graph. Remove all the imported spliced vertex types and generate them automatically from the edge types.